### PR TITLE
BE - notable perils

### DIFF
--- a/backend/ordd_api/__init__.py
+++ b/backend/ordd_api/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.22.0"
+__version__ = "0.23.0"
 MAIL_SUBJECT_PREFIX = "Open Data for Resilience Index"

--- a/backend/ordd_api/views.py
+++ b/backend/ordd_api/views.py
@@ -974,6 +974,8 @@ class Score(object):
 
                 ret_score.append(row)
 
+        th_notable = country.thinkhazard_appl.all()
+
         perils_counters = ret['perils_counters']
         for peril in KeyTag.objects.filter(
                 is_peril=True).order_by('name'):
@@ -984,9 +986,16 @@ class Score(object):
                 **fullscore_filterargs)
             count = peril_queryset.count()
             fullcount = fullscore_queryset.count()
+
+            if peril in th_notable:
+                notable = True
+            else:
+                notable = False
+
             perils_counters.append({'name': peril.name,
                                     'count': count,
-                                    'fullcount': fullcount})
+                                    'fullcount': fullcount,
+                                    'notable': notable})
 
         dsname_set = {x[0] for x in queryset.values_list(
             'keydataset__dataset').distinct()}


### PR DESCRIPTION
In the country view in the grouping per perils section each peril has a new boolean 'notable' field inherited from ThinkHazard! data.
Tests are running here: https://ci.openquake.org/job/zdevel_open-risk-data-dashboard/43/