### PR TITLE
create 'missing_datasets' list don't taking in account active filtering

### DIFF
--- a/backend/ordd_api/__init__.py
+++ b/backend/ordd_api/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.24.1"
+__version__ = "0.24.2"
 MAIL_SUBJECT_PREFIX = "Open Data for Resilience Index"

--- a/backend/ordd_api/views.py
+++ b/backend/ordd_api/views.py
@@ -926,6 +926,10 @@ class Score(object):
             raise Http404()
         queryset = Dataset.objects.filter(
             country__iso2=country_id).order_by('keydataset__pk')
+
+        dsname_set = {x[0] for x in queryset.values_list(
+            'keydataset__dataset').distinct()}
+
         applicability = request.query_params.getlist('applicability')
         category = request.query_params.getlist('category')
         if applicability:
@@ -1036,9 +1040,6 @@ class Score(object):
                                     'count': count,
                                     'fullcount': fullcount,
                                     'notable': notable})
-
-        dsname_set = {x[0] for x in queryset.values_list(
-            'keydataset__dataset').distinct()}
 
         for dsname in KeyDatasetName.objects.all().exclude(
                 pk__in=dsname_set).order_by('category', 'name'):


### PR DESCRIPTION
With this PR we make the list of missing datasets filtering-independent.