### PR TITLE
add full csv datasets dump view

### DIFF
--- a/backend/ordd_api/urls.py
+++ b/backend/ordd_api/urls.py
@@ -9,7 +9,7 @@ from .views import (
     ProfileDetails, ProfilePasswordUpdate, ProfilePasswordReset,
     ProfileCommentSendView, UserCreateView, UserDetailsView,
     RegistrationView, ProfileDatasetListCreateView, ProfileDatasetDetailsView,
-    DatasetListView, DatasetDetailsView, VersionGet,
+    DatasetListView, DatasetDetailsView, DatasetsDumpView, VersionGet,
     ScoringWorldGet, ScoringCountryDetailsGet, ScoringWorldCategoriesGet)
 
 from .keydatasets_views import (
@@ -43,6 +43,7 @@ urlpatterns = [
     url(r'^dataset/(?P<pk>[0-9]+)$',
         DatasetDetailsView.as_view(), name="dataset_details"),
 
+    url(r'^datasets_dump$', DatasetsDumpView.as_view(), name="datasets_dump"),
 
     url(r'^user/$', UserCreateView.as_view(), name="user_create"),
     url(r'^user/(?P<pk>[0-9]+)$',

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ Django==1.11.1
 psycopg2==2.7.1
 djangorestframework==3.6.3
 django-cors-headers==2.1.0
+djangorestframework-csv==2.0.0
 randstr==0.1.2
 django-jenkins==0.110.0
 # django-admin-view-permission==0.9


### PR DESCRIPTION
At `/datasets_dump`any registered user can download all datasets in csv format.
Tags list is dumped as a concatenation of  ` | ` separated strings.
Urls list is dumped as a concatenation of ` | ` separated urlencoded strings.
