### PR TITLE
Be registration refactoring

### DIFF
--- a/backend/ordd_api/__init__.py
+++ b/backend/ordd_api/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.25.0"
+__version__ = "0.27.0"
 MAIL_SUBJECT_PREFIX = "Open Data for Resilience Index"

--- a/backend/ordd_api/serializers.py
+++ b/backend/ordd_api/serializers.py
@@ -165,7 +165,8 @@ class RegistrationSerializer(serializers.ModelSerializer):
                 user.save()
                 optin = OptIn(user=user)
                 optin.save()
-                Profile.objects.update_or_create(user=user, defaults=profile_data)
+                Profile.objects.update_or_create(user=user,
+                                                 defaults=profile_data)
 
                 subject = ('%s: registration for user %s'
                            % (MAIL_SUBJECT_PREFIX, user.username))

--- a/backend/ordd_api/serializers.py
+++ b/backend/ordd_api/serializers.py
@@ -138,10 +138,14 @@ class UserSerializer(serializers.ModelSerializer):
 
 class RegistrationSerializer(serializers.ModelSerializer):
     email = serializers.EmailField(required=True)
+    title = serializers.CharField(source='profile.title', allow_blank=True)
+    institution = serializers.CharField(source='profile.institution',
+                                        allow_blank=True)
 
     class Meta:
         model = User
-        fields = ('username', 'password', 'is_active', 'email')
+        fields = ('username', 'password', 'is_active', 'email',
+                  'first_name', 'last_name', 'groups', 'title', 'institution')
         extra_kwargs = {'password': {'write_only': True},
                         'is_active': {'write_only': True},
                         'email': {'write_only': True}}
@@ -149,6 +153,7 @@ class RegistrationSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         try:
             with transaction.atomic():
+                profile_data = validated_data.pop('profile', None)
                 user = super().create(validated_data)
                 try:
                     validate_password(validated_data['password'])
@@ -160,6 +165,8 @@ class RegistrationSerializer(serializers.ModelSerializer):
                 user.save()
                 optin = OptIn(user=user)
                 optin.save()
+                Profile.objects.update_or_create(user=user, defaults=profile_data)
+
                 subject = ('%s: registration for user %s'
                            % (MAIL_SUBJECT_PREFIX, user.username))
                 # use 'http' because where 'https' is required an automatic


### PR DESCRIPTION
This PR solve issue #88 allowing pass all user informations during the first step of registration process.
Test are green here: https://ci.openquake.org/job/zdevel_open-risk-data-dashboard/55/