### PR TITLE
fix to manage new urls during dataset update added

### DIFF
--- a/backend/ordd_api/__init__.py
+++ b/backend/ordd_api/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.33.0"
+__version__ = "0.33.1"
 MAIL_SUBJECT_PREFIX = "Open Data for Resilience Index"

--- a/backend/ordd_api/views.py
+++ b/backend/ordd_api/views.py
@@ -33,7 +33,7 @@ from .serializers import (
     DatasetListSerializer, DatasetPutSerializer, DatasetsDumpSerializer)
 from .models import (Region, Country, OptIn, Dataset, KeyDataset,
                      KeyDatasetName, KeyCategory, KeyTag,
-                     my_random_key, Profile)
+                     my_random_key, Profile, Url)
 from .mailer import mailer
 from ordd_api import __version__, MAIL_SUBJECT_PREFIX
 from ordd.settings import EMAIL_CONFIRM_PROTO
@@ -627,6 +627,18 @@ class DatasetDetailsView(generics.RetrieveUpdateDestroyAPIView):
         except:
             pass
         return DatasetListSerializer
+
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.get('partial', False)
+        instance = self.get_object()
+
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        urls_new = serializer.initial_data['url']
+
+        for url_new in urls_new:
+            Url.objects.get_or_create(url=url_new)
+
+        return super(DatasetDetailsView, self).update(request, *args, **kwargs)
 
     def perform_update(self, serializer):
         # to take a picture of the field before update we follow


### PR DESCRIPTION
During `Dataset` instance update new `Url`s (many to many relation) are not automatically managed by **Django Rest Framework**, fixed overriding `update` view method.