### PR TITLE
Fix update urls [2]

### DIFF
--- a/backend/ordd_api/__init__.py
+++ b/backend/ordd_api/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.33.1"
+__version__ = "0.33.2"
 MAIL_SUBJECT_PREFIX = "Open Data for Resilience Index"

--- a/backend/ordd_api/serializers.py
+++ b/backend/ordd_api/serializers.py
@@ -271,8 +271,8 @@ class DatasetPutSerializer(serializers.ModelSerializer):
     country = serializers.SlugRelatedField(slug_field='iso2',
                                            queryset=Country.objects.all(
                                            ).order_by('name'))
-    url = serializers.SlugRelatedField(slug_field='url',
-                                       queryset=Url.objects.all(), many=True)
+    url = CreateSlugRelatedField(slug_field='url',
+                                 queryset=Url.objects.all(), many=True)
     tag = serializers.SlugRelatedField(slug_field='name',
                                        queryset=KeyTag.objects.all(),
                                        many=True)

--- a/backend/ordd_api/views.py
+++ b/backend/ordd_api/views.py
@@ -628,17 +628,28 @@ class DatasetDetailsView(generics.RetrieveUpdateDestroyAPIView):
             pass
         return DatasetListSerializer
 
-    def update(self, request, *args, **kwargs):
-        partial = kwargs.get('partial', False)
-        instance = self.get_object()
-
-        serializer = self.get_serializer(instance, data=request.data, partial=partial)
-        urls_new = serializer.initial_data['url']
-
-        for url_new in urls_new:
-            Url.objects.get_or_create(url=url_new)
-
-        return super(DatasetDetailsView, self).update(request, *args, **kwargs)
+#
+#  NOTE: this part is became obsolete after creation of url items inside serializers
+#       remove it if not create side-effects
+#
+#    def update(self, request, *args, **kwargs):
+#        logger.error('here we are 2')
+#        partial = kwargs.get('partial', False)
+#        instance = self.get_object()
+#
+#        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+#        # urls_new = serializer.initial_data['url']
+#
+#        # for url_new in urls_new:
+#        #     url, created = Url.objects.get_or_create(url=url_new)
+#        #     if created:
+#        #         logger.error('created add')
+#        #         instance.url.add(url)
+#        #     elif url not in instance.url_set.all():
+#        #         logger.error('get add')
+#        #         instance.url.add(url)
+#
+#        return super(DatasetDetailsView, self).update(request, *args, **kwargs)
 
     def perform_update(self, serializer):
         # to take a picture of the field before update we follow


### PR DESCRIPTION
A case was not covered:
  editing a previous inserted dataset instance and try to add a new URL not works because the related serializer wasn't fixed in the previous 'fix update urls' PR.