### PR TITLE
Use base URL as an API prefix

### DIFF
--- a/frontend/js/angular/app.js
+++ b/frontend/js/angular/app.js
@@ -4,7 +4,6 @@
 
 var RodiApp = angular.module('RodiApp', ['ngTable']);
 
-// var baseUrl = 'http://localhost:63342/open-risk-data-dashboard/frontend/';
 function getLocation(href) {
     var match = href.match(/^(https?\:)\/\/(([^:\/?#]*)(?:\:([0-9]+))?)([\/]{0,1}[^?#]*)(\?[^#]*|)(#.*|)$/);
     return match && {
@@ -20,12 +19,12 @@ function getLocation(href) {
 }
 
 var spli_url = getLocation(window.location.href);
-// var baseUrl = 'https://index.opendri.org/api/';
 var baseUrl = spli_url.protocol + '//' + spli_url.host + '/';
 //var baseUrl = 'http://localhost:63342/RODI/frontend/';
 
-var baseAPIurl = 'https://index.opendri.org/api/'; // Sviluppo
-//var baseAPIurl = spli_url.protocol + '//' + spli_url.host + '/api/';
+var baseAPIurl = '/api/';
+//var baseAPIurl = 'https://index.opendri.org/api/';
+//var baseAPIurl = 'https://dev.riskopendata.org/api/';
 
 RodiApp.config(function($locationProvider) {
 


### PR DESCRIPTION
This binds the frontend with the same server API HTTP endpoint.

fixes #311