### PR TITLE
instead of 'dev.riskopendata.org/exp/' use 'exp.riskopendata.org'

### DIFF
--- a/frontend/js/angular/app.js
+++ b/frontend/js/angular/app.js
@@ -18,11 +18,8 @@ function getLocation(href) {
     }
 }
 
-// use this with '/exp' to publish manually on experimental 'http-exp'
-// var exp_prefix = '/exp'
-var exp_prefix = '';
 var spli_url = getLocation(window.location.href);
-var baseUrl = spli_url.protocol + '//' + spli_url.host + exp_prefix + '/';
+var baseUrl = spli_url.protocol + '//' + spli_url.host + '/';
 //var baseUrl = 'http://localhost:63342/RODI/frontend/';
 
 //
@@ -34,7 +31,7 @@ var baseUrl = spli_url.protocol + '//' + spli_url.host + exp_prefix + '/';
 //     to have full access to development backend from
 //     your local development installation
 //
-var baseAPIurl = exp_prefix + '/api/';
+var baseAPIurl = '/api/';
 //var baseAPIurl = 'https://dev.riskopendata.org/api/';
 
 RodiApp.config(function($locationProvider) {

--- a/infrastructure/nginx/sites-available/development
+++ b/infrastructure/nginx/sites-available/development
@@ -2,13 +2,13 @@ server {
 	listen 80;
 	listen [::]:80;
 
-	server_name _;
+	server_name dev.riskopendata.org dev.riskopendata.eu;
 
 	root /var/www/html;
 	index index.html index.htm;
 
-	access_log  /var/log/nginx/access.log combined;
-	error_log   /var/log/nginx/error.log  error;
+	access_log  /var/log/nginx/access-dev.log combined;
+	error_log   /var/log/nginx/error-dev.log  error;
 
 	keepalive_timeout 20s;
 	sendfile  on;
@@ -72,30 +72,12 @@ server {
 		try_files $uri $uri/ =404;
 	}
 
-	location /exp {
-		alias /var/www/html-exp/;
-		# First attempt to serve request as file, then
-		# as directory, then fall back to displaying a 404.
-		try_files $uri $uri/ =404;
-		access_log  /var/log/nginx/access-exp.log combined;
-		error_log   /var/log/nginx/error-exp.log  error;
-	}
-
-
 	location /static {
 		proxy_set_header    Host                $http_host;
 		proxy_set_header    X-Real-IP           $remote_addr;
 		proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
 		proxy_set_header    X-Forwarded-Proto   $scheme;
 		proxy_pass http://localhost:8001/static;
-	}
-
-	location /exp/static {
-		proxy_set_header    Host                $http_host;
-		proxy_set_header    X-Real-IP           $remote_addr;
-		proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-		proxy_set_header    X-Forwarded-Proto   $scheme;
-		proxy_pass http://localhost:8002/static;
 	}
 
 	location /api {
@@ -105,8 +87,91 @@ server {
 		proxy_set_header    X-Forwarded-Proto   $scheme;
 		proxy_pass http://localhost:8001/api;
 	}
+}
 
-        location /exp/api {
+server {
+	listen 80;
+	listen [::]:80;
+
+	server_name exp.riskopendata.org exp.riskopendata.eu;
+
+	root /var/www/html-exp;
+	index index.html index.htm;
+
+	access_log  /var/log/nginx/access-exp.log combined;
+	error_log   /var/log/nginx/error-exp.log  error;
+
+	keepalive_timeout 20s;
+	sendfile  on;
+	tcp_nopush  on;
+
+	# Compression
+	gzip on;
+	gzip_comp_level 5;
+	gzip_min_length 256;
+	gzip_proxied any;
+	gzip_vary  on;
+	gzip_types
+	application/atom+xml
+	application/javascript
+	application/json
+	application/ld+json
+	application/manifest+json
+	application/rss+xml
+	application/vnd.geo+json
+	application/vnd.ms-fontobject
+	application/x-font-ttf
+	application/x-web-app-manifest+json
+	application/xhtml+xml
+	application/xml
+	font/opentype
+	image/bmp
+	image/svg+xml
+	image/x-icon
+	text/cache-manifest
+	text/css
+	text/plain
+	text/vcard
+	text/vnd.rim.location.xloc
+	text/vtt
+	text/x-component
+		text/x-cross-domain-policy;
+
+	charset utf-8;
+	charset_types
+	text/css
+	text/plain
+	text/vnd.wap.wml
+	application/javascript
+	application/json
+	application/rss+xml
+		application/xml;
+
+	error_page 404 error_404.html;
+
+	# Security
+	add_header X-XSS-Protection "1; mode=block" always;
+	add_header X-Content-Type-Options nosniff always;
+	add_header X-Frame-Options SAMEORIGIN always;
+
+	# Cross Domain API
+	add_header "Access-Control-Allow-Origin" "*";
+
+	location / {
+		# First attempt to serve request as file, then
+		# as directory, then fall back to displaying a 404.
+		try_files $uri $uri/ =404;
+	}
+
+	location /static {
+		proxy_set_header    Host                $http_host;
+		proxy_set_header    X-Real-IP           $remote_addr;
+		proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+		proxy_set_header    X-Forwarded-Proto   $scheme;
+		proxy_pass http://localhost:8002/static;
+	}
+
+        location /api {
                 proxy_set_header    Host                $http_host;
                 proxy_set_header    X-Real-IP           $remote_addr;
                 proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;


### PR DESCRIPTION
More proper configuration for the hand managed experimental instance of BE and FE.
@daniviga @CIMAManuel 