### PR TITLE
Proxy /api/ to https://dev.riskopendata.org/api/

### DIFF
--- a/frontend/wsrv-config.json
+++ b/frontend/wsrv-config.json
@@ -1,0 +1,9 @@
+{
+    "proxy": {
+        "/api/{p*}": {
+            "options": {
+                "uri": "https://dev.riskopendata.org/api/{p}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
When using `npm start` command