### PR TITLE
Make the main navigation even on all pages

### DIFF
--- a/frontend/about.html
+++ b/frontend/about.html
@@ -70,69 +70,29 @@
 </head>
 <body ng-app="RodiApp" ng-controller="RodiCtrl">
 
+<nav class="navbar navbar-main">
+  <div class="container">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+        <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+          <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+        </svg>
+      </a>
+    </div>
 
-<!--
-<div class="container-fluid">
-    &lt;!&ndash; Section HEADER - INIZIO &ndash;&gt;
-    <section id="rodi_header">
+    <div class="collapse navbar-collapse" id="top-navbar-collapse">
+      <mainmenu></mainmenu>
+    </div>
+  </div>
+</nav>
 
-        <div class="row  ">
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-                <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3">
-                    <a href="" ng-click="changeview('index.html', '0')" data-toggle="tooltip" title="Home">
-                        <img src="img/template/rodi_logo_new.png" alt="Open Data for Resilience Initiative" class="img-responsive pull-left" />
-                    </a>
-                </div>
-                <div class="col-xs-9 col-sm-9 col-md-9 col-lg-9">
-
-                    <mainmenu ></mainmenu>
-                    &lt;!&ndash;<button type="button" class="navbar-toggle navbar-toggle-left-black " data-toggle="collapse" data-target="#menu-hazard" aria-expanded="false">
-                        <span class="sr-only">Toggle navigation</span>
-                        <span class="icon-bar icon-bar-white"></span>
-                        <span class="icon-bar icon-bar-white"></span>
-                        <span class="icon-bar icon-bar-white"></span>
-                    </button>&ndash;&gt;
-                    <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website" aria-expanded="false">
-                        <span class="sr-only">Toggle navigation</span>
-                        <span class="icon-bar icon-bar-white"></span>
-                        <span class="icon-bar icon-bar-white"></span>
-                        <span class="icon-bar icon-bar-white"></span>
-                    </button>
-                </div>
-            </div>
-        </div>
-        <div class="row" id="top-menu">
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-                &lt;!&ndash;<hazardmenu></hazardmenu>&ndash;&gt;
-                <h2 class="page_title ">ABOUT</h2>
-            </div>
-        </div>
-    </section>
-    -->
 <div class="container">
-    <!-- Section HEADER - INIZIO -->
-
-    <section class="unscroll" id="rodi_header">
-        <div class="row  ">
-            <div class="col-xs-8 col-sm-3 " style="color:black;">
-                <a ng-if="bHome" href="" ng-click="changeview('index.html', '0')">
-                    <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                        <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                    </svg>
-                </a>
-            </div>
-
-            <div class="col-xs-4 col-sm-9 ">
-                <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website" aria-expanded="false">
-                    <span class="sr-only">Toggle navigation</span>
-                    <i class="fa fa-bars"></i>
-                </button>
-
-                <mainmenu ></mainmenu>
-            </div>
-
-        </div>
-
         <div class="row" id="top-menu">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
                 <!--<hazardmenu></hazardmenu>-->

--- a/frontend/confirm_registration.html
+++ b/frontend/confirm_registration.html
@@ -72,34 +72,29 @@
 </head>
 <body ng-app="RodiApp" ng-controller="RodiCtrlConfirmMail">
 
+<nav class="navbar navbar-main">
+  <div class="container">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+        <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+          <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+        </svg>
+      </a>
+    </div>
+
+    <div class="collapse navbar-collapse" id="top-navbar-collapse">
+      <mainmenu></mainmenu>
+    </div>
+  </div>
+</nav>
 
 <div class="container">
-    <!-- Section HEADER - INIZIO -->
-    <section id="rodi_header">
-
-        <div class="row  ">
-            <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">-->
-            <div class="col-xs-8 col-sm-3 " style="color:black;">
-                <a ng-if="bHome" href="" ng-click="changeview('index.html', '0')">
-                    <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                        <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                    </svg>
-                </a>
-            </div>
-
-            <div class="col-xs-4 col-sm-9 ">
-                <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website" aria-expanded="false">
-                    <span class="sr-only">Toggle navigation</span>
-                    <i class="fa fa-bars"></i>
-                </button>
-
-                <mainmenu ></mainmenu>
-            </div>
-
-
-
-        </div>
-    </section>
         <div class="row" id="top-menu">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
                 <!--<hazardmenu></hazardmenu>-->

--- a/frontend/contribute.html
+++ b/frontend/contribute.html
@@ -84,31 +84,27 @@
 </head>
 <body ng-app="RodiApp" ng-controller="RodiCtrl">
 
-
-    <!-- Section HEADER - INIZIO -->
-    <section id="rodi_header">
-      <div class="container">
-        <div class="row">
-            <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">-->
-            <div class="col-xs-8 col-sm-3 " style="color:black;">
-                <a ng-if="bHome" href="" ng-click="changeview('index.html', '0')">
-                    <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                        <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                    </svg>
-                </a>
-            </div>
-
-            <div class="col-xs-4 col-sm-9 ">
-                <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website" aria-expanded="false">
-                    <span class="sr-only">Toggle navigation</span>
-                    <i class="fa fa-bars"></i>
-                </button>
-
-                <mainmenu ></mainmenu>
-            </div>
-        </div>
+  <nav class="navbar navbar-main">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+          <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+          </svg>
+        </a>
       </div>
-    </section>
+
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <mainmenu></mainmenu>
+      </div>
+    </div>
+  </nav>
 
     <div class="container">
         <div class="row" id="top-menu">

--- a/frontend/countries.html
+++ b/frontend/countries.html
@@ -78,37 +78,29 @@
 </head>
 
 <body ng-app="RodiApp" ng-controller="RodiCtrl">
-
+  <nav class="navbar navbar-main">
     <div class="container">
-        <!-- Section HEADER - INIZIO -->
-        <section id="rodi_header">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+          <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+          </svg>
+        </a>
+      </div>
 
-            <div class="row  ">
-                <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">-->
-                <div class="col-xs-8 col-sm-3 " style="color:black;">
-                    <a ng-if="bHome" href="" ng-click="changeview('index.html', '0')">
-                        <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                        </svg>
-                    </a>
-                </div>
-
-                <div class="col-xs-5 col-sm-9 ">
-                    <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse"
-                        data-target="#menu-website" aria-expanded="false">
-                        <span class="sr-only">Toggle navigation</span>
-                        <i class="fa fa-bars"></i>
-                    </button>
-
-                    <mainmenu></mainmenu>
-                </div>
-
-
-
-            </div>
-        </section>
-
-
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <mainmenu></mainmenu>
+      </div>
+    </div>
+  </nav>
+  
+    <div class="container">
         <div class="row">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 text-center">
                 <h1 class="page_title">Explore countries</h1>

--- a/frontend/css/land.css
+++ b/frontend/css/land.css
@@ -177,13 +177,6 @@ html {
   font-family: courier; }
 
 /* fix the body to be full screen */
-body {
-  height: 100%;
-  margin: 0;
-  position: absolute;
-  width: 100%;
-  overflow-x: hidden; }
-
 .container-fluid.land {
   padding-left: 0;
   padding-right: 0; }

--- a/frontend/css/rodi_css.css
+++ b/frontend/css/rodi_css.css
@@ -359,15 +359,11 @@ Logo color
     font-size: 56.0275px;
 }
 
-
 svg.logo_icon {
-    width: 100%;
-    /* height: 100px; */
     stroke-linecap: round;
     stroke-width: 0;
-    stroke:red;
-    max-width: 200px;
-    max-height: 85px;
+    max-height: 50px;
+    max-width: 150px;
 }
 
 svg.logo_partner {
@@ -801,25 +797,21 @@ Navbar
     background-color: #232323;
 }
 
-.navbar-toggle-right-black {
-    float: right;
+.navbar-toggle {
     background-color: #ee3036;
-    margin: 30px 30px 0;
     color: white;
-}
-
-.navbar-toggle-right-black[aria-expanded="true"] i,
-.navbar-toggle-right-black[aria-expanded="false"] i {
     transition: all 0.25s ease-in-out;
 }
 
-.navbar-toggle-right-black[aria-expanded="true"] i {
-    transform: rotate(90deg);
-
+.navbar-toggle[aria-expanded="true"] {
+    background-color: #fff;
+}
+.navbar-toggle[aria-expanded="true"] .icon-bar {
+    background-color: #ee3036;
 }
 
-.icon-bar-white {
-    background-color: #ffffff;
+.navbar-toggle .icon-bar {
+    background-color: #fff;
 }
 
 .navbar-nav span {
@@ -827,22 +819,6 @@ Navbar
     font-size: 10px;
     text-transform: uppercase;
     margin-top: 1em;
-}
-
-.nav li a, .nav li p {
-    display: flex;
-    /* flex-direction: column; */
-    /* justify-content:center; */
-    /* align-items: center; */
-    /* align-content: center; */
-    padding: 10px;
-    line-height: 1;
-    /* margin-top: 5px; */
-}
-
-.nav li a i {
-    /* z-index: -1; */
-    overflow: hidden;
 }
 
 .nav .invert:hover, .invert:focus {
@@ -864,15 +840,24 @@ a.invert {
     padding: 10px 5px;
 }
 
-mainmenu .navbar {
-    margin: 1.5em 1em 0;
-}
-
 /*
 ======================================
         Navbar menu hazard
 ======================================
 */
+
+.navbar-main {
+    margin: 1.5em 0;
+}
+
+.navbar-brand {
+  padding: 0;
+}
+
+.navbar-main .navbar-nav>li>a {
+  padding-left: 8px;
+  padding-right: 8px;
+}
 
 .nav a {
     color: #ee3036;
@@ -948,7 +933,8 @@ mainmenu .navbar {
 }
 #menu-hazard .nav > li > a {max-width: 110px;}
 
-#menu-hazard .nav > li > a i, #menu-hazard .nav > li > p i {
+#menu-hazard .nav > li > a i,
+#menu-hazard .nav > li > p i {
     border-radius: 50%;
     border: 2px solid red;
     border-color: #EE3036;
@@ -1587,10 +1573,11 @@ fieldset[disabled] .btn-custom.active {
 
 .login_form_box {
     position: absolute;
-    width: 90%;
+    width: 50%;
     top: 25%;
-    left: 0;
-    background-color: rgba(0, 0, 0, .8);
+    left: 50%;
+    margin-left: -25%;
+    background-color: rgba(0, 0, 0, .9);
     z-index: 100;
     color: #ffffff;
     padding: 20px;
@@ -1634,10 +1621,6 @@ fieldset[disabled] .btn-custom.active {
 
 .form-control:focus {
     border-bottom: solid 4px #007899;
-}
-
-.navbar-header .form-control:focus {
-    width: 150%;
 }
 
 .form-control,
@@ -1813,7 +1796,7 @@ hr {
     margin-top: -60px;
 }
 
-.navbar {
+.navbar-default {
     margin-bottom: 0;
 }
 
@@ -1911,16 +1894,6 @@ responsive
 @media screen and (min-width: 1024px) {
 }
 
-@media screen and (max-width: 1024px) and (orientation: landscape) {
-    .nav > li > a {
-        padding: 10px;
-    }
-
-    .nav > li > a > i {
-        font-size: 2em;
-    }
-}
-
 @media screen and (max-width: 980px) {
     .page_title {
         font-size: 40px;
@@ -1929,10 +1902,6 @@ responsive
     .page_title + .lead {
       margin-top: -20px;
       margin-bottom: 20px;
-    }
-
-    .nav > li > a > i {
-        font-size: 2em;
     }
 
     .head_sep {
@@ -1996,13 +1965,6 @@ responsive
         margin-top: 0px;
     }
 
-    #rodi_header .img-responsive {
-
-        /*max-width:calc(100vh/3);*/
-        max-height: 80px;
-        margin: 20px auto;
-    }
-
     #menu-website .nav > li > a {
         flex-direction: row;
         justify-content: flex-start;
@@ -2021,10 +1983,6 @@ responsive
 
     /*mainmenu .navbar,
     hazardmenu .navbar,*/
-    .navbar-header {
-        margin-top: -50px;
-    }
-
     .partner_box {
         margin: inherit;
     }
@@ -2084,19 +2042,6 @@ z-index: 100;*/
 
     #menu-website li .logout a {
         padding: 0 1em;
-    }
-}
-
-@media screen and (max-width: 480px) {
-    #rodi_header .img-responsive {
-        height: 50px;
-        margin-top: 40px;
-    }
-
-    .collapse.in .navbar-nav {
-        z-index: 1;
-        padding: 0 0 30vw;
-
     }
 }
 
@@ -2393,7 +2338,7 @@ h2.odfri_title_red {
 }
 
 .logout {
-    padding-left: 1em; /* display: inline-flex; */
+    padding-left: 1em;
     white-space: nowrap;
 }
 

--- a/frontend/css/rodi_css.css
+++ b/frontend/css/rodi_css.css
@@ -792,11 +792,6 @@ Navbar
 ===============================================================================================
 */
 
-.navbar-toggle-left-black {
-    float: left;
-    background-color: #232323;
-}
-
 .navbar-toggle {
     background-color: #ee3036;
     color: white;
@@ -812,13 +807,6 @@ Navbar
 
 .navbar-toggle .icon-bar {
     background-color: #fff;
-}
-
-.navbar-nav span {
-    color: #a0a0a0;
-    font-size: 10px;
-    text-transform: uppercase;
-    margin-top: 1em;
 }
 
 .nav .invert:hover, .invert:focus {
@@ -880,6 +868,16 @@ a.invert {
     color: #A8A8A8;
     cursor: disabled;
 }
+
+.hazard-nav span {
+    color: #a0a0a0;
+    font-size: 10px;
+    text-transform: uppercase;
+    margin-top: 1em;
+    line-height: 1.2;
+}
+
+
   #menu-hazard .disabled i[class*="icon-"] {
       border-color: #A8A8A8;
   }
@@ -910,28 +908,28 @@ a.invert {
 /*#menu-hazard {font-size: 2em;}*/
 
 #menu-hazard {
-    display: flex;
+  display: flex;
+  justify-content: center;
 }
 
 #menu-hazard .nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    /* width: 100%; */
-    padding:0 1em;
-    /* align-self: flex-end; */
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }
-#menu-hazard .nav:first-child  {  justify-content:flex-end;}
-#menu-hazard .nav:last-child  {  justify-content:flex-start;}
 
 #menu-hazard .nav > li.search {
     flex-grow: 3;
 }
 
 #menu-hazard .nav > li {
-    /* flex-grow: 1; */
+  flex: 0;
 }
-#menu-hazard .nav > li > a {max-width: 110px;}
+#menu-hazard .nav > li > a {
+  display: flex;
+  max-width: 110px;
+  padding: 10px;
+}
 
 #menu-hazard .nav > li > a i,
 #menu-hazard .nav > li > p i {
@@ -972,9 +970,6 @@ a.invert {
 #menu-hazard .nav > li.search > div > a:hover {
     border-radius: 50%;
 }
-
-/*#menu-hazard .nav>li.active>a span {padding:1em;}*/
-/*#menu-hazard .nav>li.unactive>a span { background: white;}*/
 
 /*
 ==============================================================================
@@ -1753,8 +1748,7 @@ hr {
     border-right: solid 3px red;
     height: auto;
     padding-left: 1em;
-    z-index:0;
-    /* margin-right: 1em; */
+    margin-right: 1em;
 }
 
 
@@ -1796,7 +1790,8 @@ hr {
     margin-top: -60px;
 }
 
-.navbar-default {
+.navbar-default,
+.navbar-hazard {
     margin-bottom: 0;
 }
 
@@ -1804,9 +1799,6 @@ hr {
     display: flex;
     align-items: center;
 }
-
-/*.navbar-toggle-right-black,
-.navbar-toggle-left-black {    margin: 15px;  }*/
 
 /*
 ================================================
@@ -1892,6 +1884,16 @@ responsive
 }
 
 @media screen and (min-width: 1024px) {
+  #menu-hazard .nav {
+    flex-wrap: nowrap;
+  }
+
+  #menu-hazard .nav:first-child {
+    justify-content: flex-end;
+  }
+  #menu-hazard .nav:last-child {
+    justify-content: flex-start;
+  }
 }
 
 @media screen and (max-width: 980px) {
@@ -1942,12 +1944,17 @@ responsive
     }
 
     #menu-hazard,
-    #menu-hazard>.nav>li>a {flex-direction:column; align-items:center;}
+    #menu-hazard>.nav>li>a {
+      flex-direction:column;
+      align-items:center;
+    }
+
     #menu-hazard>.nav>li>a span {padding-top:1em;}
     .menu_sep_countries {
-    border-right:inherit;
-    border-bottom:3px solid red;
-    width:75%;
+      border-right:inherit;
+      border-bottom:3px solid red;
+      margin: 1em 0;
+      width:75%;
     }
 
     a.invert {
@@ -2115,17 +2122,6 @@ z-index: 100;*/
 .modal-header h4 {
     font-size: 25px;
 }
-
-/*
-
-.table>thead:first-child>tr:first-child>th
-{
-    text-align: left;
-}
-
-
-
-*/
 
 .table.dataset th,
 .table.dataset td {

--- a/frontend/dataset_details.html
+++ b/frontend/dataset_details.html
@@ -74,31 +74,29 @@
 </head>
 
 <body ng-app="RodiApp" ng-controller="RodiCtrlDataset">
+  <nav class="navbar navbar-main">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+          <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+          </svg>
+        </a>
+      </div>
+
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <mainmenu></mainmenu>
+      </div>
+    </div>
+  </nav>
 
     <div class="container">
-        <!-- Section HEADER - INIZIO -->
-        <section id="rodi_header">
-
-            <div class="row  ">
-                <div class="col-xs-8 col-sm-3 " style="color:black;">
-                    <a ng-if="bHome" href="" ng-click="changeview('index.html', '0')">
-                        <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                        </svg>
-                    </a>
-                </div>
-
-                <div class="col-xs-5 col-sm-9">
-                    <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse"
-                        data-target="#menu-website" aria-expanded="false">
-                        <span class="sr-only">Toggle navigation</span>
-                        <i class="fa fa-bars"></i>
-                    </button>
-
-                    <mainmenu></mainmenu>
-                </div>
-            </div>
-
             <div class="row" id="top-menu">
                 <div class="page-header">
                     <h1 class="page_title">{{objDatasetView.keydataset.dataset.name}} <small>{{countryDesc}}</small></h1>
@@ -793,8 +791,7 @@
 
             </div>
 
-        </section>
-        <!-- Section HEADER - FINE -->
+        </div>
     </div>
 
     <footer class="footer">

--- a/frontend/dataset_list.html
+++ b/frontend/dataset_list.html
@@ -74,32 +74,29 @@
 </head>
 
 <body ng-app="RodiApp" ng-controller="RodiCtrlDatasetList">
+  <nav class="navbar navbar-main">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+          <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+          </svg>
+        </a>
+      </div>
+
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <mainmenu></mainmenu>
+      </div>
+    </div>
+  </nav>
 
   <div class="container">
-    <!-- Section HEADER - INIZIO -->
-    <section id="rodi_header">
-
-      <div class="row  ">
-        <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">-->
-        <div class="col-xs-8 col-sm-3 " style="color:black;">
-          <a ng-if="bHome" href="" ng-click="changeview('index.html', '0')">
-            <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-              <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-            </svg>
-          </a>
-        </div>
-
-        <div class="col-xs-4 col-sm-9 ">
-          <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website"
-            aria-expanded="false">
-            <span class="sr-only">Toggle navigation</span>
-            <i class="fa fa-bars"></i>
-          </button>
-
-          <mainmenu></mainmenu>
-        </div>
-      </div>
-    </section>
 
     <div class="row" id="top-menu">
       <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">

--- a/frontend/error_404.html
+++ b/frontend/error_404.html
@@ -77,40 +77,27 @@
 </head>
 <body ng-app="RodiApp" ng-controller="RodiCtrl">
 
-
-
+  <nav class="navbar navbar-main">
     <div class="container">
-        <!-- Section HEADER - INIZIO -->
-        <section id="rodi_header">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+          <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+          </svg>
+        </a>
+      </div>
 
-            <div class="row  ">
-                <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">-->
-                <div class="col-xs-8 col-sm-3 " style="color:black;">
-                    <a ng-if="bHome" href="" ng-click="changeview('index.html', '0')">
-                        <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                        </svg>
-                    </a>
-                </div>
-
-                <div class="col-xs-4 col-sm-9 ">
-                    <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website" aria-expanded="false">
-                        <span class="sr-only">Toggle navigation</span>
-                        <i class="fa fa-bars"></i>
-                    </button>
-
-                    <mainmenu ></mainmenu>
-                </div>
-
-
-
-            </div>
-
-
-
-        </section>
-        <!-- Section HEADER - FINE -->
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <mainmenu></mainmenu>
+      </div>
     </div>
+  </nav>
 
     <!-- Section image counters and buttons -->
     <section id="rodi_main">

--- a/frontend/getdata.html
+++ b/frontend/getdata.html
@@ -70,37 +70,31 @@
 
 </head>
 <body ng-app="RodiApp" ng-controller="RodiCtrl">
+  <nav class="navbar navbar-main">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+          <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+          </svg>
+        </a>
+      </div>
 
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <mainmenu></mainmenu>
+      </div>
+    </div>
+  </nav>
 
 <div class="container">
     <!-- Section HEADER - INIZIO -->
-    <section id="rodi_header">
-
-        <div class="row  ">
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-                <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3">
-                    <a href="" ng-click="changeview('index.html', '0')" data-toggle="tooltip" title="Home">
-                        <img src="img/template/rodi_logo_new.png" alt="Open Data for Resilience Initiative" class="img-responsive pull-left" />
-                    </a>
-                </div>
-                <div class="col-xs-9 col-sm-9 col-md-9 col-lg-9">
-
-                    <mainmenu ></mainmenu>
-                    <!--<button type="button" class="navbar-toggle navbar-toggle-left-black " data-toggle="collapse" data-target="#menu-hazard" aria-expanded="false">
-                        <span class="sr-only">Toggle navigation</span>
-                        <span class="icon-bar icon-bar-white"></span>
-                        <span class="icon-bar icon-bar-white"></span>
-                        <span class="icon-bar icon-bar-white"></span>
-                    </button>-->
-                    <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website" aria-expanded="false">
-                        <span class="sr-only">Toggle navigation</span>
-                        <span class="icon-bar icon-bar-white"></span>
-                        <span class="icon-bar icon-bar-white"></span>
-                        <span class="icon-bar icon-bar-white"></span>
-                    </button>
-                </div>
-            </div>
-        </div>
+      
         <div class="row" id="top-menu">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
                 <!--<hazardmenu></hazardmenu>-->
@@ -108,7 +102,7 @@
                 <h1 class="page_title ">GET THE DATA</h1>
             </div>
         </div>
-    </section>
+
     <!-- Section HEADER - FINE -->
     <div class="row">
         <div class="col-xs-12 col-sm-10 col-md-6 col-xs-offset-0 col-sm-offset-1 col-md-offset-3 text-content">

--- a/frontend/img/logo.svg
+++ b/frontend/img/logo.svg
@@ -16,7 +16,7 @@
 	<text transform="matrix(1 0 0 1 29.7466 640.543)" style="font-family:'Variable-Black'; font-size:109.9418px;">Resilience Index</text>
 	<text transform="matrix(1 0 0 1 732.3064 704.0646)" style="font-family:'Variable-Black'; font-size:56.0275px;">beta</text>
 </g>
-<symbol id="logo_open_data_full" viewBox="-200 0 1400 60">
+<symbol id="logo_open_data_full" viewBox="-200 50 1100 60">
 	<g id="logo">
 		<path class="st0" fill="#EE3036" d="M-74.2,157.5c-46.4,0-84-37.6-84-84c0-25.9,11.7-49.1,30.2-64.5l19,20.4c-12.9,10.2-21.2,25.9-21.2,43.6
 			c0,30.7,24.8,55.5,55.5,55.5s55.5-24.8,55.5-55.5S-44,17.5-74.7,17.5c-5.2,0-10.2,0.7-15,2.1L-99.9-6.5c8.1-2.6,16.7-4,25.7-4

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -70,35 +70,27 @@
 
 <div class="alert alert-success" role="alert" style="width:100%;text-align: center;margin-bottom: 0px">This is a beta version. While you navigate the website, we invite you to provide feedback through <a class="alert-link" href="https://docs.google.com/forms/d/e/1FAIpQLSddVOUyn1-cCpdF9wc2RgAEpHPCTcO-jhT03DKnx9cU3x22PQ/viewform" target="_blank">this form</a>. Many thanks!</div>
 
-<div class="container">
-    <!-- Section HEADER - INIZIO -->
-    <!--<section id="rodi_header">-->
+<nav class="navbar navbar-main">
+  <div class="container">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+        <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+          <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+        </svg>
+      </a>
+    </div>
 
-        <div class="row  ">
-            <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">-->
-                <div class="col-xs-8 col-sm-3 " style="color:black;">
-                    <!--<img src="img/template/rodi_logo_new_beta.png" alt="Open Data for Resilience Initiative" class="img-responsive pull-left" />-->
-                    <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                        <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                    </svg>
-                </div>
-
-                <div class="col-xs-4 col-sm-9 ">
-                    <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website" aria-expanded="false">
-                        <span class="sr-only">Toggle navigation</span>
-                        <i class="fa fa-bars"></i>
-                    </button>
-
-
-                    <mainmenu ></mainmenu>
-                </div>
-
-
-            <!--</div>-->
-        </div>
-    <!--</section>-->
-    <!-- Section HEADER - FINE -->
-</div>
+    <div class="collapse navbar-collapse" id="top-navbar-collapse">
+      <mainmenu></mainmenu>
+    </div>
+  </div>
+</nav>
 
 
 

--- a/frontend/methodology.html
+++ b/frontend/methodology.html
@@ -73,33 +73,29 @@
 
 </head>
 <body ng-app="RodiApp" ng-controller="RodiCtrl">
+  <nav class="navbar navbar-main">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+          <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+          </svg>
+        </a>
+      </div>
 
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <mainmenu></mainmenu>
+      </div>
+    </div>
+  </nav>
 <div class="container" id="startReading">
-    <!-- Section HEADER - INIZIO -->
-    <section class="unscroll" id="rodi_header">
 
-        <div class="row  ">
-            <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">-->
-            <div class="col-xs-8 col-sm-3 " style="color:black;">
-                <a ng-if="bHome" href="" ng-click="changeview('index.html', '0')">
-                    <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                        <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                    </svg>
-                </a>
-            </div>
-
-            <div class="col-xs-4 col-sm-9 ">
-                <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website" aria-expanded="false">
-                    <span class="sr-only">Toggle navigation</span>
-                    <i class="fa fa-bars"></i>
-                </button>
-
-                <mainmenu ></mainmenu>
-            </div>
-
-
-
-        </div>
         <div class="row" id="top-menu">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
                 <!--<hazardmenu></hazardmenu>-->
@@ -126,7 +122,6 @@
                 </div>
             </div>
         </div>
-    </section>
     <!-- Section HEADER - FINE -->
 
     <!-- Country Matrix -->

--- a/frontend/password_reset.html
+++ b/frontend/password_reset.html
@@ -68,32 +68,29 @@
 </head>
 <body ng-app="RodiApp" ng-controller="RodiCtrlResetPassword">
 
+  <nav class="navbar navbar-main">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+          <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+          </svg>
+        </a>
+      </div>
+
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <mainmenu></mainmenu>
+      </div>
+    </div>
+  </nav>
 
 <div class="container">
-    <!-- Section HEADER - INIZIO -->
-    <section id="rodi_header">
-
-        <div class="row  ">
-            <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">-->
-            <div class="col-xs-8 col-sm-3 " style="color:black;">
-                <!--<img src="img/template/rodi_logo_new_beta.png" alt="Open Data for Resilience Initiative" class="img-responsive pull-left" />-->
-                <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                    <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                </svg>
-            </div>
-
-            <div class="col-xs-4 col-sm-9 ">
-                <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website" aria-expanded="false">
-                    <span class="sr-only">Toggle navigation</span>
-                    <i class="fa fa-bars"></i>
-                </button>
-
-                <mainmenu ></mainmenu>
-            </div>
-
-
-
-        </div>
 
         <div class="row" id="top-menu">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
@@ -102,8 +99,6 @@
                 <h1 class="page_title ">Reset password</h1>
             </div>
         </div>
-    </section>
-    <!-- Section HEADER - FINE -->
 
     <!-- Content Page -->
     <br />

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -70,34 +70,29 @@
 
 </head>
 <body ng-app="RodiApp" ng-controller="RodiCtrl">
+  <nav class="navbar navbar-main">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+          <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+          </svg>
+        </a>
+      </div>
 
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <mainmenu></mainmenu>
+      </div>
+    </div>
+  </nav>
 
 <div class="container">
-    <!-- Section HEADER - INIZIO -->
-    <section id="rodi_header">
-
-        <div class="row  ">
-            <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">-->
-            <div class="col-xs-8 col-sm-3 " style="color:black;">
-                <a ng-if="bHome" href="" ng-click="changeview('index.html', '0')">
-                    <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                        <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                    </svg>
-                </a>
-            </div>
-
-            <div class="col-xs-4 col-sm-9 ">
-                <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website" aria-expanded="false">
-                    <span class="sr-only">Toggle navigation</span>
-                    <i class="fa fa-bars"></i>
-                </button>
-
-                <mainmenu ></mainmenu>
-            </div>
-
-
-
-        </div>
 
         <div class="row" id="top-menu">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
@@ -106,11 +101,6 @@
                 <h1 class="page_title ">PRIVACY POLICY</h1>
             </div>
         </div>
-    </section>
-    <!-- Section HEADER - FINE -->
-
-
-
 
     <!-- Country Matrix -->
     <div class="row">

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -72,44 +72,35 @@
 </head>
 
 <body ng-app="RodiApp" ng-controller="RodiCtrl">
+  <nav class="navbar navbar-main">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+          <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+          </svg>
+        </a>
+      </div>
 
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <mainmenu></mainmenu>
+      </div>
+    </div>
+  </nav>
 
     <div class="container">
-        <!-- Section HEADER - INIZIO -->
-        <section id="rodi_header">
-
-            <div class="row  ">
-                <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">-->
-                <div class="col-xs-8 col-sm-3 " style="color:black;">
-                    <a href="index.html" ng-click="changeview('index.html', '0')">
-                      <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                          <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                      </svg>
-                    </a>
-                </div>
-
-                <div class="col-xs-4 col-sm-9 ">
-                    <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse"
-                        data-target="#menu-website" aria-expanded="false">
-                        <span class="sr-only">Toggle navigation</span>
-                        <i class="fa fa-bars"></i>
-                    </button>
-
-                    <mainmenu></mainmenu>
-                </div>
-
-
-
-            </div>
             <div class="row" id="top-menu">
                 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
                     <!--<hazardmenu></hazardmenu>-->
                     <h1 class="page_title ">REGISTER</h1>
                 </div>
             </div>
-        </section>
-        <!-- Section HEADER - FINE -->
-
 
         <!-- Content page -->
 

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -73,35 +73,28 @@
 
 </head>
 <body ng-app="RodiApp" ng-controller="RodiCtrl">
-
+  <nav class="navbar navbar-main">
     <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="./"  ng-click="changepage('./')">
+          <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
+            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
+          </svg>
+        </a>
+      </div>
 
-        <!-- Section HEADER - INIZIO -->
-        <section id="rodi_header">
-
-            <div class="row  ">
-                <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">-->
-                <div class="col-xs-8 col-sm-3 " style="color:black;">
-                    <a ng-if="bHome" href="" ng-click="changeview('index.html', '0')">
-                        <svg class="logo_icon" aria-hidden="true" focusable="false" fill="currentColor;">
-                            <use xlink:href="img/logo.svg#logo_open_data_full"></use>
-                        </svg>
-                    </a>
-                </div>
-
-                <div class="col-xs-4 col-sm-9 ">
-                    <button type="button" class="navbar-toggle navbar-toggle-right-black " data-toggle="collapse" data-target="#menu-website" aria-expanded="false">
-                        <span class="sr-only">Toggle navigation</span>
-                        <i class="fa fa-bars"></i>
-                    </button>
-
-                    <mainmenu ></mainmenu>
-                </div>
-
-
-
-            </div>
-
+      <div class="collapse navbar-collapse" id="top-navbar-collapse">
+        <mainmenu></mainmenu>
+      </div>
+    </div>
+  </nav>
+    <div class="container">
 
             <div class="row">
                 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 text-center">
@@ -193,9 +186,6 @@
 
                 </div>
             </div>-->
-
-        </section>
-        <!-- Section HEADER - FINE -->
 
         <!-- Section PARTNER - INIZIO -->
         <!--<section id="news">

--- a/frontend/views/login_form.html
+++ b/frontend/views/login_form.html
@@ -18,9 +18,9 @@
         <input type="password" placeholder="password" class="form-control" ng-model="usr_psw">
         <i class="fa fa-2x icon-register"></i>
     </div>
-    <div class="form text-center"><input type="button" class="btn btn-custom btn-lg" value="RESET PASSWORD" ng-click="resetPassword()" ng-if="bResetPassword" /></div>
+    <div class="form text-center"><input type="button" class="btn btn-primary btn-lg" value="RESET PASSWORD" ng-click="resetPassword()" ng-if="bResetPassword" /></div>
     <br /><br />
-    <div class="form text-center"><input type="button" class="btn btn-custom btn-lg" value="LOGIN" ng-click="loginUser()" ng-if="!bResetPassword" /></div>
+    <div class="form text-center"><input type="button" class="btn btn-primary btn-lg" value="LOGIN" ng-click="loginUser()" ng-if="!bResetPassword" /></div>
 
     <br /><br />
     <div class="text-center">
@@ -32,4 +32,3 @@
 
 
 </div>
-

--- a/frontend/views/web_menu.html
+++ b/frontend/views/web_menu.html
@@ -10,37 +10,20 @@
 <script>vex.defaultOptions.className = 'vex-theme-default';</script>
 <!-- VEX DIALOG - POPUP FINE -->
 
-
-
-<div class="pull-right">
-        <nav class="navbar navbar-main">
-        <div class="container-fluid">
-            <div class="row">
-                <!-- mobile display -->
-                <!-- Website menu -->
-                <div class="collapse navbar-collapse" id="menu-website">
-                    <ul class="nav navbar-nav flex-container flex-row">
-                        <li><a href="contribute.html" ng-click="changeview('contribute.html', '1')">Submit a dataset</a></li>
-                        <li><a href="countries.html" ng-click="changeview('countries.html', '5')">Explore countries</a></li>
-                        <li><a href="dataset_list.html?idcountry=AA" ng-click="changeview('dataset_list.html?idcountry=AA', '6')">Global data</a></li>
-                        <li><a href="methodology.html" ng-click="changeview('methodology.html', '2')">Documentation</a></li>
-                        <li><a href="about.html" ng-click="changeview('about.html', '9')">About</a></li>
-                        <li ng-if="!bLogin"><a href="#login_form" ng-click="loginform($event)">Login</a></li>
-                        <li ng-if="!bLogin"><a href="register.html" ng-click="changepage('register.html')">Register</a></li>
-                        <li ng-if="bLogin" >
-                            <div class="logout">
-                                <a href="" ng-click="logout()" class="invert round flex-container flex-col">
-                                    <p class="flex-row">Log out - <b>{{userinfo.username}}</b></p>
-                                </a>
-                            </div>
-                        </li>
-                    </ul>
-                </div><!-- /.navbar-collapse -->
-            </div>
-        </div>
-        <!-- /.container-fluid -->
-    </nav>
-</div>
+<ul class="nav navbar-nav navbar-right">
+  <li><a href="contribute.html" ng-click="changeview('contribute.html', '1')">Submit a dataset</a></li>
+  <li><a href="countries.html" ng-click="changeview('countries.html', '5')">Explore countries</a></li>
+  <li><a href="dataset_list.html?idcountry=AA" ng-click="changeview('dataset_list.html?idcountry=AA', '6')">Global data</a></li>
+  <li><a href="methodology.html" ng-click="changeview('methodology.html', '2')">Documentation</a></li>
+  <li><a href="about.html" ng-click="changeview('about.html', '9')">About</a></li>
+  <li ng-if="!bLogin"><a href="#login_form" ng-click="loginform($event)">Login</a></li>
+  <li ng-if="!bLogin"><a href="register.html" ng-click="changepage('register.html')">Register</a></li>
+  <li ng-if="bLogin" class="logout">
+    <a href="" ng-click="logout()" class="invert round">
+        Log out - <b>{{userinfo.username}}</b>
+    </a>
+  </li>
+</ul>
 
 
 <loginform></loginform>


### PR DESCRIPTION
This pull request does several things:

1. it aligns the top menu with [Bootstrap navbar](https://getbootstrap.com/docs/3.3/components/#navbar) structure, to benefit from existing CSS and to reduce side effects
1. it separates the styles used for the top navigation and the other navigations (like the hazard icons)
1. it adjusts slightly how the brand logo is displayed, in order to cut whitespaces embedded in the image itself

# Main navigation screenshots

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/138627/49077159-efccc700-f23a-11e8-81d2-d8178dce6356.png">

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/138627/49077195-fb1ff280-f23a-11e8-98a3-cd527feaa418.png">

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/138627/49077223-0d019580-f23b-11e8-9aa1-5fe09b540cd9.png">

<img width="548" alt="image" src="https://user-images.githubusercontent.com/138627/49077237-1559d080-f23b-11e8-97a1-0661c8737538.png">

<img width="536" alt="image" src="https://user-images.githubusercontent.com/138627/49077273-24d91980-f23b-11e8-8e90-661e1aa58b78.png">


# Hazards screenshots

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/138627/49077577-e7c15700-f23b-11e8-9d15-046e00c9b9bb.png">

<img width="895" alt="image" src="https://user-images.githubusercontent.com/138627/49077594-f1e35580-f23b-11e8-9bb1-e8c5f4d0aa3d.png">

<img width="555" alt="image" src="https://user-images.githubusercontent.com/138627/49077628-045d8f00-f23c-11e8-8d20-7f8428e7561a.png">
