### PR TITLE
Truncate links with CSS only

### DIFF
--- a/frontend/css/rodi_css.css
+++ b/frontend/css/rodi_css.css
@@ -58,6 +58,14 @@ h3, h4, h5, h6
   border-bottom: none;
 }
 
+.single-line {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: " […]";
+  white-space: nowrap;
+}
+
 /* ************************************ */
 /* R.O.D.I. STYLE ELEMENTS - INIZIO     */
 /* ************************************ */

--- a/frontend/dataset_details.html
+++ b/frontend/dataset_details.html
@@ -223,11 +223,11 @@
                             {{objDataset.notes}}</span>
                         <br /> <br />
                         <span><span class="odfri_dataset_label">Links to data and metadata:</span>
-                            <div class="rodi_ul">
-                                <a href="{{chekprotocol(link)}}" target="_blank" ng-repeat="link in selectedLink">
-                                    - {{formatLink(link)}}<br />
-                                </a>
-                            </div>
+                            <ul class="list-unstyled">
+                              <li ng-repeat="link in selectedLink">
+                                <a href="{{link}}" class="single-line" target="_blank" noreferrer noopener>{{link}}</a>
+                              </li>
+                            </ul>
                         </span><br />
                         <span><span class="odfri_dataset_label">Dataset submitted by:</span> {{objDataset.owner}}</span>
 

--- a/frontend/js/angular/controller_dataset_details.js
+++ b/frontend/js/angular/controller_dataset_details.js
@@ -434,46 +434,6 @@ RodiApp.controller('RodiCtrlDataset', ['$scope', 'RodiSrv', '$window', '$filter'
         $scope.bEdit = false;
     }
 
-    $scope.formatLink = function(link){
-
-        //Check protocol
-        var indexProtocolCheck = link.indexOf('http');
-
-        if(indexProtocolCheck == -1)
-        {
-            //Add protocol to link
-            link = "http://" + link;
-        }
-
-        var shortLink = "";
-
-        if (link.length > 70)
-        {
-          shortLink = link.substr(0, 70);
-          shortLink = shortLink + ' [...]';
-        } else {
-                shortLink = link;
-        }
-
-        return shortLink;
-
-    }
-
-    $scope.chekprotocol = function(strLink)
-    {
-        //Check protocol
-        var indexProtocolCheck = strLink.indexOf('http');
-
-        if(indexProtocolCheck == -1)
-        {
-            //Add protocol to link
-            strLink = "http://" + strLink;
-        }
-
-        return strLink;
-
-    }
-
     function initDataset ()
     {
         // Get dataset info from profile API
@@ -545,7 +505,16 @@ RodiApp.controller('RodiCtrlDataset', ['$scope', 'RodiSrv', '$window', '$filter'
                 $scope.newLink = "";
                 $scope.countryDesc = "";
 
-                $scope.selectedLink = $scope.objDataset.url;
+                $scope.selectedLink = $scope.objDataset.url.map(function(url){
+                  if (/^https?/.test(url) === false) {
+                    return 'http' + url;
+                  }
+                  else if (/^https?:\/\//.test(url) === false) {
+                    return 'http://' + url;
+                  }
+
+                  return url;
+                });
 
                 // Load country list
                 RodiSrv.getCountryList().then(function(response){

--- a/frontend/js/angular/controller_dataset_list.js
+++ b/frontend/js/angular/controller_dataset_list.js
@@ -335,19 +335,4 @@ RodiApp.controller('RodiCtrlDatasetList', ['$scope', 'RodiSrv', '$location', '$w
 
     }
 
-    $scope.formatLink = function(link){
-        var shortLink = "";
-
-        if (link.length > 70)
-        {
-            shortLink = link.substr(0, 70);
-            shortLink = shortLink + ' [...]';
-        } else {
-            shortLink = link;
-        }
-
-        return shortLink;
-
-    }
-
 } ]);


### PR DESCRIPTION
This way, truncation is responsive, based on the parent element width.

👁‍🗨 [**Live Preview**](https://deploy-preview-357--index-opendri-preview.netlify.com/)

![capture d ecran - 2018-12-10 a 19 05 04](https://user-images.githubusercontent.com/138627/49751755-8d4ddf00-fcae-11e8-9f95-c5feeeda854c.png)
---
![capture d ecran - 2018-12-10 a 19 04 54](https://user-images.githubusercontent.com/138627/49751758-8de67580-fcae-11e8-9ff2-23b3e369f07c.png)
---
![capture d ecran - 2018-12-10 a 19 04 48](https://user-images.githubusercontent.com/138627/49751759-8de67580-fcae-11e8-94ed-77d48bf4d39a.png)

fix #235