### PR TITLE
issue #376: dataset submit error

### DIFF
--- a/frontend/js/angular/service.js
+++ b/frontend/js/angular/service.js
@@ -510,8 +510,8 @@ RodiApp.service("RodiSrv", ['$http', '$filter', function($http, $filter)
                 is_open_licence_txt:"",
                 is_prov_timely:"",
                 is_prov_timely_last:"",
-                is_pub_available: "--",
-                is_reviewed: false,
+                is_pub_available: "",
+                is_reviewed: "",
                 keydataset:{
                     applicability:[],
                     category: "0",


### PR DESCRIPTION
Correct empty object definition.
The problem was in "is_pub_available" and "is_reviewed".
For a consistency object check these two parameters must be empty.