### PR TITLE
Display countries list with new open data indicators

### DIFF
--- a/frontend/about.html
+++ b/frontend/about.html
@@ -60,10 +60,6 @@
     </script>
 
 
-    <!--ADOBE typekit-->
-    <!--<script src="https://use.typekit.net/yxp8fxq.js"></script>-->
-    <!--<script>try{Typekit.load({ async: true });}catch(e){}</script>-->
-
     <!-- RODI css -->
     <link href="css/rodi_css.css" rel="stylesheet">
 

--- a/frontend/contribute.html
+++ b/frontend/contribute.html
@@ -44,23 +44,9 @@
     <script src="js/angular/directive.js" type="text/javascript"></script>
     <!-- RODI APP -->
 
-    <!--ADOBE typekit-->
-    <!--<script src="https://use.typekit.net/yxp8fxq.js"></script>-->
-    <!--<script>try{Typekit.load({ async: true });}catch(e){}</script>-->
-
     <!-- RODI css -->
     <link href="css/rodi_css.css" rel="stylesheet">
     <link href="css/style_map.css" rel="stylesheet">
-
-    <!-- Guida: https://medium.com/@tweededbadger/tutorial-dynamic-data-driven-svg-map-with-angularjs-b112fdec421d -->
-    <!--<script src="js/change_svg.js"></script>-->
-
-    <!-- Tooltip init -->
-    <script>
-        $(function () {
-            $('[data-toggle="tooltip"]').tooltip()
-        })
-    </script>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-80600133-2"></script>
@@ -642,16 +628,16 @@
                                         </td>
                                         <td title="'Open data criteria'">
                                             <div class="dataset_value">
-                                                <i class="fa fa-check-circle-o" aria-hidden="{{ds.is_existing}}" data-toggle="tooltip" title="{{questions[0].desc}}"></i>
-                                                <i class="fa fa-desktop" aria-hidden="{{ds.is_digital_form}}" data-toggle="tooltip" title="{{questions[1].desc}}"></i>
-                                                <i class="fa fa-cloud" aria-hidden="{{ds.is_avail_online}}" data-toggle="tooltip" title="{{questions[2].desc}}"></i>
-                                                <i class="fa fa-tag" aria-hidden="{{ds.is_avail_online_meta}}" data-toggle="tooltip" title="{{questions[3].desc}}"></i>
-                                                <i class="fa fa-copy" aria-hidden="{{ds.is_bulk_avail}}" data-toggle="tooltip" title="{{questions[4].desc}}"></i>
-                                                <i class="fa fa-keyboard-o" aria-hidden="{{ds.is_machine_read}}" data-toggle="tooltip" title="{{questions[5].desc}}"></i>
-                                                <i class="fa fa-eye" aria-hidden="{{ds.is_pub_available}}" data-toggle="tooltip" title="{{questions[6].desc}}"></i>
-                                                <i class="fa fa-dollar" aria-hidden="{{ds.is_avail_for_free}}" data-toggle="tooltip" title="{{questions[7].desc}}"></i>
-                                                <i class="fa fa-unlock-alt" aria-hidden="{{ds.is_open_licence}}" data-toggle="tooltip" title="{{questions[8].desc}}"></i>
-                                                <i class="fa fa-clock-o" aria-hidden="{{ds.is_prov_timely}}" data-toggle="tooltip" title="{{questions[9].desc}}"></i>
+                                                <i class="fa fa-check-circle-o" aria-hidden="{{ds.is_existing}}" ng-tooltip="{{questions[0].desc}}"></i>
+                                                <i class="fa fa-desktop" aria-hidden="{{ds.is_digital_form}}" ng-tooltip="{{questions[1].desc}}"></i>
+                                                <i class="fa fa-cloud" aria-hidden="{{ds.is_avail_online}}" ng-tooltip="{{questions[2].desc}}"></i>
+                                                <i class="fa fa-tag" aria-hidden="{{ds.is_avail_online_meta}}" ng-tooltip="{{questions[3].desc}}"></i>
+                                                <i class="fa fa-copy" aria-hidden="{{ds.is_bulk_avail}}" ng-tooltip="{{questions[4].desc}}"></i>
+                                                <i class="fa fa-keyboard-o" aria-hidden="{{ds.is_machine_read}}" ng-tooltip="{{questions[5].desc}}"></i>
+                                                <i class="fa fa-eye" aria-hidden="{{ds.is_pub_available}}" ng-tooltip="{{questions[6].desc}}"></i>
+                                                <i class="fa fa-dollar" aria-hidden="{{ds.is_avail_for_free}}" ng-tooltip="{{questions[7].desc}}"></i>
+                                                <i class="fa fa-unlock-alt" aria-hidden="{{ds.is_open_licence}}" ng-tooltip="{{questions[8].desc}}"></i>
+                                                <i class="fa fa-clock-o" aria-hidden="{{ds.is_prov_timely}}" ng-tooltip="{{questions[9].desc}}"></i>
                                             </div>
                                         </td>
                                         <!--<td title="'Year'" filter="{ create_time: 'number'}" sortable="'create_time'" class="text-center">
@@ -812,16 +798,16 @@
                                                 <td>
                                                     <!-- Open data criteria -->
                                                     <div class=" dataset_value">
-                                                        <i class="fa fa-check-circle-o" aria-hidden="{{ds.is_existing}}" data-toggle="tooltip" title="{{questions[0].desc}}"></i>
-                                                        <i class="fa fa-desktop" aria-hidden="{{ds.is_digital_form}}" data-toggle="tooltip" title="{{questions[1].desc}}"></i>
-                                                        <i class="fa fa-cloud" aria-hidden="{{ds.is_avail_online}}" data-toggle="tooltip" title="{{questions[2].desc}}"></i>
-                                                        <i class="fa fa-tag" aria-hidden="{{ds.is_avail_online_meta}}" data-toggle="tooltip" title="{{questions[3].desc}}"></i>
-                                                        <i class="fa fa-copy" aria-hidden="{{ds.is_bulk_avail}}" data-toggle="tooltip" title="{{questions[4].desc}}"></i>
-                                                        <i class="fa fa-keyboard-o" aria-hidden="{{ds.is_machine_read}}" data-toggle="tooltip" title="{{questions[5].desc}}"></i>
-                                                        <i class="fa fa-eye" aria-hidden="{{ds.is_pub_available}}" data-toggle="tooltip" title="{{questions[6].desc}}"></i>
-                                                        <i class="fa fa-dollar" aria-hidden="{{ds.is_avail_for_free}}" data-toggle="tooltip" title="{{questions[7].desc}}"></i>
-                                                        <i class="fa fa-unlock-alt" aria-hidden="{{ds.is_open_licence}}" data-toggle="tooltip" title="{{questions[8].desc}}"></i>
-                                                        <i class="fa fa-clock-o" aria-hidden="{{ds.is_prov_timely}}" data-toggle="tooltip" title="{{questions[9].desc}}"></i>
+                                                        <i class="fa fa-check-circle-o" aria-hidden="{{ds.is_existing}}" ng-tooltip="{{questions[0].desc}}"></i>
+                                                        <i class="fa fa-desktop" aria-hidden="{{ds.is_digital_form}}" ng-tooltip="{{questions[1].desc}}"></i>
+                                                        <i class="fa fa-cloud" aria-hidden="{{ds.is_avail_online}}" ng-tooltip="{{questions[2].desc}}"></i>
+                                                        <i class="fa fa-tag" aria-hidden="{{ds.is_avail_online_meta}}" ng-tooltip="{{questions[3].desc}}"></i>
+                                                        <i class="fa fa-copy" aria-hidden="{{ds.is_bulk_avail}}" ng-tooltip="{{questions[4].desc}}"></i>
+                                                        <i class="fa fa-keyboard-o" aria-hidden="{{ds.is_machine_read}}" ng-tooltip="{{questions[5].desc}}"></i>
+                                                        <i class="fa fa-eye" aria-hidden="{{ds.is_pub_available}}" ng-tooltip="{{questions[6].desc}}"></i>
+                                                        <i class="fa fa-dollar" aria-hidden="{{ds.is_avail_for_free}}" ng-tooltip="{{questions[7].desc}}"></i>
+                                                        <i class="fa fa-unlock-alt" aria-hidden="{{ds.is_open_licence}}" ng-tooltip="{{questions[8].desc}}"></i>
+                                                        <i class="fa fa-clock-o" aria-hidden="{{ds.is_prov_timely}}" ng-tooltip="{{questions[9].desc}}"></i>
                                                     </div>
                                                 </td>
                                                 <td>{{ds.create_time | date: 'dd/MM/yyyy'}}</td>

--- a/frontend/countries.html
+++ b/frontend/countries.html
@@ -184,19 +184,19 @@
                         </th>
                         <td>
                             <div class="progress" ng-if="country.datasets_count > 0" ng-tooltip title="State of openness for this country." data-placement="left">
-                                <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{country.fullscores_count}}" ng-title="{{country.name}} has {{country.fullscores_count}} open datasets."
+                                <div ng-show="country.fullscores_count > 0" class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{country.fullscores_count}}" ng-title="{{country.name}} has {{country.fullscores_count}} open datasets."
                                      aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.fullscores_count / keydatasetsCount * 100}}%;">
-                                    {{country.fullscores_count || ' '}}
+                                    {{country.fullscores_count}}
                                 </div>
 
-                                <div class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="{{country.datasets_count}}" ng-title="{{country.name}} has {{country.datasets_count-country.fullscores_count}} restricted datasets."
+                                <div ng-show="country.datasets_count-country.fullscores_count > 0" class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="{{country.datasets_count}}" ng-title="{{country.name}} has {{country.datasets_count-country.fullscores_count}} restricted datasets."
                                      aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{(country.datasets_count-country.fullscores_count)/keydatasetsCount * 100}}%;">
-                                    {{country.datasets_count-country.fullscores_count || ' '}}
+                                    {{country.datasets_count-country.fullscores_count}}
                                 </div>
 
-                                <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="{{country.datasets_count}}" ng-title="{{country.name}} has {{country.datasets_closed_count}} closed datasets."
+                                <div ng-show="country.datasets_closed_count > 0" class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="{{country.datasets_count}}" ng-title="{{country.name}} has {{country.datasets_closed_count}} closed datasets."
                                      aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_closed_count/keydatasetsCount * 100}}%;">
-                                    {{country.datasets_closed_count || '?'}}
+                                    {{country.datasets_closed_count}}
                                 </div>
                             </div>
 

--- a/frontend/countries.html
+++ b/frontend/countries.html
@@ -176,43 +176,48 @@
                         </th>
                         <th>
                             <div class="flex-container flex-row text-center">
-                                <span class="sort_arrow_up" ng-click="sortBy('datasets_unknown_count', false)" tabindex="0"><i class="fa fa-caret-up" aria-hidden="true" ng-style="{color: sortField == 'fullscores_count' && !sortDirection?  '#cb2431' : '#232323'}"></i></span>
-                                <span class="sort_arrow_down" ng-click="sortBy('datasets_unknown_count', true)" tabindex="0"><i class="fa fa-caret-down" aria-hidden="true" ng-style="{color: sortField == 'fullscores_count' && sortDirection?  '#cb2431' : '#232323'}"></i></span>
+                                <span class="sort_arrow_up" ng-click="sortBy('datasets_count', true)" tabindex="0"><i class="fa fa-caret-up" aria-hidden="true" ng-style="{color: sortField == 'fullscores_count' && !sortDirection?  '#cb2431' : '#232323'}"></i></span>
+                                <span class="sort_arrow_down" ng-click="sortBy('datasets_count', false)" tabindex="0"><i class="fa fa-caret-down" aria-hidden="true" ng-style="{color: sortField == 'fullscores_count' && sortDirection?  '#cb2431' : '#232323'}"></i></span>
                             </div>
                         </th>
                     </tr>
                     </thead>
                     <tbody ng-if="!bLoadingTabel" ng-cloak>
                     <!--  Country with dataset submitted -->
-                    <tr ng-repeat="country in allCountries | orderBy: sortField:sortDirection | filter: filterBy | filter: {name:countrySearchFilter, region:regionSearchFilter}" ng-click="changepage('dataset_list.html?idcountry=' + country.wb_id, $event)" title="Click to see datasets for this country" tabindex="0">
+                    <tr ng-repeat="country in allCountries | orderBy: sortField:sortDirection | filter: filterBy | filter: {name:countrySearchFilter, region:regionSearchFilter}" ng-click="country.datasets_count ? changepage('dataset_list.html?idcountry=' + country.wb_id, $event) : changepage('contribute.html?country_id=' + country.wb_id, $event)" title="Click to see datasets for this country" tabindex="0">
                         <th scope="row">
                           <a ng-href="dataset_list.html?idcountry={{country.wb_id}}">{{country.name}}</a>
                         </th>
                         <td>
-                            <div class="progress" ng-if="country.score !== undefined" title="Average scores of all datasets considered for this country. If a dataset does not exist or has not been submitted, its score is 0.">
-                                <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{country.score}}"
-                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_open_count / keydatasetsCount * 100}}%;">
-                                    {{country.datasets_open_count || 0}}
+                            <div class="progress" ng-if="country.datasets_count > 0" title="State of openness for this country.">
+                                <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{country.fullscores_count}}" ng-title="{{country.name}} has {{country.fullscores_count}} open datasets."
+                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.fullscores_count / keydatasetsCount * 100}}%;">
+                                    {{country.fullscores_count || ' '}}
                                 </div>
 
-                                <div class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="{{country.datasets_count}}"
-                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_restricted_count/keydatasetsCount * 100}}%;">
-                                    {{country.datasets_restricted_count || 0}}
+                                <div class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="{{country.datasets_count}}" ng-title="{{country.name}} has {{country.datasets_count-country.fullscores_count}} restricted datasets."
+                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{(country.datasets_count-country.fullscores_count)/keydatasetsCount * 100}}%;">
+                                    {{country.datasets_count-country.fullscores_count || ' '}}
                                 </div>
 
-                                <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="{{country.datasets_count}}"
+                                <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="{{country.datasets_count}}" ng-title="{{country.name}} has {{country.datasets_closed_count}} closed datasets."
                                      aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_closed_count/keydatasetsCount * 100}}%;">
-                                    {{country.datasets_closed_count || 0}}
+                                    {{country.datasets_closed_count || '?'}}
                                 </div>
                             </div>
+
+                            <span class="text-muted" ng-if="country.datasets_count === 0">
+                              No dataset submitted.
+                              <a ng-href="contribute.html?country_id={{country.wb_id}}" ng-click="changeview('contribute.html?country_id=' + country.wb_id)">Contribute the first one</a>.
+                            </span>
 
                             <img ng-if="country.fullscores_count === undefined" src="img/template/loading.gif" alt="" style="max-width:40px;">
                         </td>
                         <td>
-                          <div class="progress" ng-if="country.fullscores_count >= 0">
-                              <div class="progress-bar" role="progressbar" aria-valuenow="{{country.fullscores_count}}"
-                                   aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_unknown_count/keydatasetsCount * 100}}%;">
-                                  {{country.datasets_unknown_count || 0}}
+                          <div class="progress" ng-if="country.datasets_count > 0">
+                              <div class="progress-bar progress-bar-default" role="progressbar" aria-valuenow="{{keydatasetsCount-country.datasets_count}}"
+                                   aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{(keydatasetsCount-country.datasets_count)/keydatasetsCount * 100}}%;">
+                                  {{keydatasetsCount-country.datasets_count}}
                               </div>
                           </div>
 
@@ -232,19 +237,6 @@
     <footer class="footer">
         <rodifooter></rodifooter>
     </footer>
-
-    <script>
-        $(document).ready(function () {
-            //            $('#tabCountries').DataTable(
-            //                {
-            //                    ordering: true,
-            //                    paging: false,
-            //                    searching: false,
-            //                    info: false
-            //                }
-            //            );
-        });
-    </script>
 
 </body>
 

--- a/frontend/countries.html
+++ b/frontend/countries.html
@@ -170,8 +170,8 @@
                         </th>
                         <th>
                             <div class="flex-container flex-row text-center">
-                                <span class="sort_arrow_up" ng-click="sortBy('datasets_count', true)" tabindex="0"><i class="fa fa-caret-up" aria-hidden="true" ng-style="{color: sortField == 'fullscores_count' && !sortDirection?  '#cb2431' : '#232323'}"></i></span>
-                                <span class="sort_arrow_down" ng-click="sortBy('datasets_count', false)" tabindex="0"><i class="fa fa-caret-down" aria-hidden="true" ng-style="{color: sortField == 'fullscores_count' && sortDirection?  '#cb2431' : '#232323'}"></i></span>
+                                <span class="sort_arrow_up" ng-click="sortBy('datasets_unknown_count', false)" tabindex="0"><i class="fa fa-caret-up" aria-hidden="true" ng-style="{color: sortField == 'datasets_count' && !sortDirection?  '#cb2431' : '#232323'}"></i></span>
+                                <span class="sort_arrow_down" ng-click="sortBy('datasets_unknown_count', true)" tabindex="0"><i class="fa fa-caret-down" aria-hidden="true" ng-style="{color: sortField == 'datasets_count' && sortDirection?  '#cb2431' : '#232323'}"></i></span>
                             </div>
                         </th>
                     </tr>
@@ -183,19 +183,19 @@
                           <a ng-href="dataset_list.html?idcountry={{country.wb_id}}">{{country.name}}</a>
                         </th>
                         <td>
-                            <div class="progress" ng-if="country.datasets_count > 0" ng-tooltip title="State of openness for this country." data-placement="left">
-                                <div ng-show="country.fullscores_count > 0" class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{country.fullscores_count}}" ng-title="{{country.name}} has {{country.fullscores_count}} open datasets."
-                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.fullscores_count / keydatasetsCount * 100}}%;">
-                                    {{country.fullscores_count}}
+                            <div class="progress" ng-if="country.datasets_count > 0" ng-tooltip="We know of {{country.datasets_open_count}} open, {{country.datasets_restricted_count}} restricted and {{country.datasets_closed_count}} closed datasets for {{country.name}}." data-placement="left">
+                                <div ng-show="country.datasets_open_count > 0" class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{country.datasets_open_count}}"
+                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_open_count / (keydatasetsCount > country.datasets_count ? keydatasetsCount : country.datasets_count) * 100}}%;">
+                                    {{country.datasets_open_count}}
                                 </div>
 
-                                <div ng-show="country.datasets_count-country.fullscores_count > 0" class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="{{country.datasets_count}}" ng-title="{{country.name}} has {{country.datasets_count-country.fullscores_count}} restricted datasets."
-                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{(country.datasets_count-country.fullscores_count)/keydatasetsCount * 100}}%;">
-                                    {{country.datasets_count-country.fullscores_count}}
+                                <div ng-show="country.datasets_restricted_count > 0" class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="{{country.datasets_restricted_count}}"
+                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_restricted_count / (keydatasetsCount > country.datasets_count ? keydatasetsCount : country.datasets_count) * 100}}%;">
+                                    {{country.datasets_restricted_count}}
                                 </div>
 
-                                <div ng-show="country.datasets_closed_count > 0" class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="{{country.datasets_count}}" ng-title="{{country.name}} has {{country.datasets_closed_count}} closed datasets."
-                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_closed_count/keydatasetsCount * 100}}%;">
+                                <div ng-show="country.datasets_closed_count > 0" class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="{{country.datasets_closed_count}}"
+                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_closed_count/ (keydatasetsCount > country.datasets_count ? keydatasetsCount : country.datasets_count) * 100}}%;">
                                     {{country.datasets_closed_count}}
                                 </div>
                             </div>
@@ -205,17 +205,17 @@
                               <a ng-href="contribute.html?country_id={{country.wb_id}}" ng-click="changeview('contribute.html?country_id=' + country.wb_id)">Contribute the first one</a>.
                             </span>
 
-                            <img ng-if="country.fullscores_count === undefined" src="img/template/loading.gif" alt="" style="max-width:40px;">
+                            <img ng-if="country.datasets_count === undefined" src="img/template/loading.gif" alt="" style="max-width:40px;">
                         </td>
                         <td>
                           <div class="progress" ng-if="country.datasets_count > 0">
-                              <div class="progress-bar progress-bar-default" role="progressbar" aria-valuenow="{{keydatasetsCount-country.datasets_count}}"
-                                   aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{(keydatasetsCount-country.datasets_count)/keydatasetsCount * 100}}%;">
-                                  {{keydatasetsCount-country.datasets_count}}
+                              <div class="progress-bar progress-bar-default" role="progressbar" aria-valuenow="{{country.datasets_unknown_count}}"
+                                   aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_unknown_count / (keydatasetsCount > country.datasets_count ? keydatasetsCount : country.datasets_count) * 100}}%;">
+                                  {{country.datasets_unknown_count}}
                               </div>
                           </div>
 
-                          <img ng-if="country.fullscores_count === undefined" src="img/template/loading.gif" alt="" style="max-width:40px;">
+                          <img ng-if="country.datasets_count === undefined" src="img/template/loading.gif" alt="" style="max-width:40px;">
                         </td>
                     </tr>
                     </tbody>

--- a/frontend/countries.html
+++ b/frontend/countries.html
@@ -9,7 +9,7 @@
     <meta content="Open Data for Resilience Index " name="description" />
     <meta content="" name="author" />
 
-    
+
 
 
     <title>OpenDRI Index - Explore countries</title>
@@ -139,14 +139,25 @@
                     <thead>
                     <tr>
                         <th title="Name of country">Country</th>
-                        <th title="Average scores of all datasets considered. If a dataset does not exist or has not been submitted, its score is 0.">
-                          Score<br> <a href="methodology.html#openness" class="small">(more details)</a>
-                        </th>
-                        <th title="Number of datasets submitted">
-                            Datasets&nbsp;submitted
+                        <th title="Average scores of all datasets considered. If a dataset does not exist or has not been submitted, its score is 0." style="width: 50%">
+                          <ul class="list-inline">
+                            <li>
+                              <span class="label label-success label-small"></span> Open Data<br>
+                              <span class="text-muted">Free to access, use and share</span>
+                            </li>
+                            <li>
+                              <span class="label label-warning label-small"></span> Restricted<br>
+                              <span class="text-muted">Technical, legal or cost restrictions</span>
+                            </li>
+                            <li>
+                              <span class="label label-danger label-small"></span> Closed<br>
+                              <span class="text-muted">Access not permitted or does not exist</span>
+                            </li>
+                          </ul>
                         </th>
                         <th title="Number of datasets fully open">
-                            Open&nbsp;data
+                          <span class="label label-default label-small"></span> Unknown<br>
+                          <span class="text-muted">No information.<br>Submission is needed</span>
                         </th>
 
                     </tr>
@@ -164,15 +175,9 @@
                             </div>
                         </th>
                         <th>
-                            <div class="flex-container flex-row">
-                                <span class="sort_arrow_up" ng-click="sortBy('datasets_count', false)" tabindex="0"><i class="fa fa-caret-up" aria-hidden="true" ng-style="{color: sortField == 'datasets_count' && !sortDirection?  '#cb2431' : '#232323'}"></i></span>
-                                <span class="sort_arrow_down" ng-click="sortBy('datasets_count', true)" tabindex="0"><i class="fa fa-caret-down" aria-hidden="true" ng-style="{color: sortField == 'datasets_count' && sortDirection?  '#cb2431' : '#232323'}"></i></span>
-                            </div>
-                        </th>
-                        <th>
                             <div class="flex-container flex-row text-center">
-                                <span class="sort_arrow_up" ng-click="sortBy('fullscores_count', false)" tabindex="0"><i class="fa fa-caret-up" aria-hidden="true" ng-style="{color: sortField == 'fullscores_count' && !sortDirection?  '#cb2431' : '#232323'}"></i></span>
-                                <span class="sort_arrow_down" ng-click="sortBy('fullscores_count', true)" tabindex="0"><i class="fa fa-caret-down" aria-hidden="true" ng-style="{color: sortField == 'fullscores_count' && sortDirection?  '#cb2431' : '#232323'}"></i></span>
+                                <span class="sort_arrow_up" ng-click="sortBy('datasets_unknown_count', false)" tabindex="0"><i class="fa fa-caret-up" aria-hidden="true" ng-style="{color: sortField == 'fullscores_count' && !sortDirection?  '#cb2431' : '#232323'}"></i></span>
+                                <span class="sort_arrow_down" ng-click="sortBy('datasets_unknown_count', true)" tabindex="0"><i class="fa fa-caret-down" aria-hidden="true" ng-style="{color: sortField == 'fullscores_count' && sortDirection?  '#cb2431' : '#232323'}"></i></span>
                             </div>
                         </th>
                     </tr>
@@ -181,37 +186,32 @@
                     <!--  Country with dataset submitted -->
                     <tr ng-repeat="country in allCountries | orderBy: sortField:sortDirection | filter: filterBy | filter: {name:countrySearchFilter, region:regionSearchFilter}" ng-click="changepage('dataset_list.html?idcountry=' + country.wb_id, $event)" title="Click to see datasets for this country" tabindex="0">
                         <th scope="row">
-                          <a ng-href="dataset_list.html?idcountry={{country.wb_id}}" class="text-muted">{{country.name}}</a>
+                          <a ng-href="dataset_list.html?idcountry={{country.wb_id}}">{{country.name}}</a>
                         </th>
                         <td>
                             <div class="progress" ng-if="country.score !== undefined" title="Average scores of all datasets considered for this country. If a dataset does not exist or has not been submitted, its score is 0.">
-                                <div class="progress-bar" role="progressbar" aria-valuenow="{{country.score}}"
-                                     aria-valuemin="0" aria-valuemax="100" style="width: {{country.score}}%;">
-                                    {{country.score}}%
+                                <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{country.score}}"
+                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_open_count / keydatasetsCount * 100}}%;">
+                                    {{country.datasets_open_count || 0}}
+                                </div>
+
+                                <div class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="{{country.datasets_count}}"
+                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_restricted_count/keydatasetsCount * 100}}%;">
+                                    {{country.datasets_restricted_count || 0}}
+                                </div>
+
+                                <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="{{country.datasets_count}}"
+                                     aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_closed_count/keydatasetsCount * 100}}%;">
+                                    {{country.datasets_closed_count || 0}}
                                 </div>
                             </div>
 
-                            <img ng-if="country.score === undefined" src="img/template/loading.gif" alt="" style="max-width:40px;">
-                        </td>
-
-                        <td>
-                            <div class="progress" ng-if="country.datasets_count > 0">
-                              <div class="progress-bar" role="progressbar" aria-valuenow="{{country.datasets_count}}"
-                                   aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_count/keydatasetsCount * 100}}%;">
-                                  {{country.datasets_count}}
-                              </div>
-                            </div>
-
-                            <span ng-if="country.datasets_count === 0">No dataset submitted</span>
-
-                            <img ng-if="country.datasets_count === undefined" src="img/template/loading.gif" alt="" style="max-width:40px;">
-                        </td>
-
+                            <img ng-if="country.fullscores_count === undefined" src="img/template/loading.gif" alt="" style="max-width:40px;">
                         <td>
                           <div class="progress" ng-if="country.fullscores_count >= 0">
                               <div class="progress-bar" role="progressbar" aria-valuenow="{{country.fullscores_count}}"
-                                   aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.fullscores_count/keydatasetsCount * 100}}%;">
-                                  {{country.fullscores_count}}
+                                   aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.datasets_unknown_count/keydatasetsCount * 100}}%;">
+                                  {{country.datasets_unknown_count || 0}}
                               </div>
                           </div>
 

--- a/frontend/countries.html
+++ b/frontend/countries.html
@@ -69,12 +69,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.12/js/jquery.dataTables.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.12/js/dataTables.bootstrap.min.js"></script>
 
-    <script>
-        $(function () {
-            $('[data-toggle="tooltip"]').tooltip()
-        })
-    </script>
-
 </head>
 
 <body ng-app="RodiApp" ng-controller="RodiCtrl">
@@ -189,7 +183,7 @@
                           <a ng-href="dataset_list.html?idcountry={{country.wb_id}}">{{country.name}}</a>
                         </th>
                         <td>
-                            <div class="progress" ng-if="country.datasets_count > 0" title="State of openness for this country.">
+                            <div class="progress" ng-if="country.datasets_count > 0" ng-tooltip title="State of openness for this country." data-placement="left">
                                 <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{country.fullscores_count}}" ng-title="{{country.name}} has {{country.fullscores_count}} open datasets."
                                      aria-valuemin="0" aria-valuemax="{{keydatasetsCount}}" style="width: {{country.fullscores_count / keydatasetsCount * 100}}%;">
                                     {{country.fullscores_count || ' '}}

--- a/frontend/countries.html
+++ b/frontend/countries.html
@@ -207,6 +207,7 @@
                             </div>
 
                             <img ng-if="country.fullscores_count === undefined" src="img/template/loading.gif" alt="" style="max-width:40px;">
+                        </td>
                         <td>
                           <div class="progress" ng-if="country.fullscores_count >= 0">
                               <div class="progress-bar" role="progressbar" aria-valuenow="{{country.fullscores_count}}"

--- a/frontend/css/table_style_20180221.css
+++ b/frontend/css/table_style_20180221.css
@@ -26,6 +26,15 @@
   padding-top: 12px;
 }
 
+.table > thead th > .list-inline {
+  display: flex;
+}
+
+.table .text-muted {
+  font-size: 14px;
+  font-weight: normal;
+}
+
 @media (max-width:768px) {
     .table > tbody > tr > td {
         white-space: normal  !important;
@@ -90,16 +99,32 @@ table.dataTable thead>tr>td.sorting
     margin-bottom: 0px;
 }
 
-.progress-bar
-{
+.progress-bar {
     padding: .25em 10px;
     background-color: #007899;
     text-align: left;
     font-size: inherit;
 }
-.progress-bar-success {
+.label-small {
+  font-size: .3em;
+  height: 14px;
+  line-height: 0;
+  width: 14px;
+  display: inline-block !important;
+}
+.progress-bar-success,
+.label-success {
     background-color: #009500;
 }
-.progress-bar-danger {
+.progress-bar-warning,
+.label-warning {
+    background-color: rgb(236, 188, 46);
+}
+.progress-bar-danger,
+.label-danger {
     background-color: #cb2431;
+}
+.progress-bar-default,
+.label-default {
+    background-color: rgb(52, 58, 64);
 }

--- a/frontend/dataset_details.html
+++ b/frontend/dataset_details.html
@@ -737,17 +737,17 @@
                   <div class=" text-center">
                       <br /><br />
                       <button class="btn btn-md btn-primary" ng-click="setEditForm()" ng-if="bReviewer && !bEdit"><i
-                              class="fa fa-pencil-square-o" aria-hidden="true" data-toggle="tooltip" title="Edit dataset"></i>
+                              class="fa fa-pencil-square-o" aria-hidden="true" ng-tooltip title="Edit dataset"></i>
                           Edit dataset</button>
                       <a ng-href="dataset_list.html?idcountry={{objDatasetView.country}}"
                           class="btn btn-md btn-primary" ng-if="!bEdit"><i class="fa fa-undo"
-                              aria-hidden="true" data-toggle="tooltip" title="Back to {{countryDesc}}"></i> Back to {{countryDesc}} datasets</a>
+                              aria-hidden="true"></i> Back to {{countryDesc}} datasets</a>
                       <div class="btn btn-md btn-warning" ng-if="(userinfo.groups[0]=='admin' || userinfo.groups[0]== 'reviewer') && bEdit"><input
                               type="checkbox" ng-model="objDataset.is_reviewed"> Dataset approved</div>
                       <button class="btn btn-md btn-success" ng-if="bEdit" ng-click="updateDataset()"><i class="fa fa-floppy-o"
-                              aria-hidden="true" data-toggle="tooltip" title="Save dataset"></i> Save dataset</button>
+                              aria-hidden="true" ng-tooltip title="Save dataset"></i> Save dataset</button>
                       <button class="btn btn-md btn-info" ng-if="bEdit" ng-click="closeRevision()"><i class="fa fa-times"
-                              aria-hidden="true" data-toggle="tooltip" title="Close edit mode"></i> Close edit mode</button>
+                              aria-hidden="true" ng-tooltip title="Close edit mode"></i> Close edit mode</button>
                       <button class="btn btn-md btn-danger" ng-if="bEdit && bReviewer" ng-click="deleteDataset()"><i
                               class="fa fa-trash-o" aria-hidden="true" title="Delete dataset"></i> Delete dataset</button>
                   </div>

--- a/frontend/dataset_list.html
+++ b/frontend/dataset_list.html
@@ -56,12 +56,6 @@
   <!--<link href="css/table_color_noheader.css" rel="stylesheet">-->
   <link href="css/table_style_20180221.css" rel="stylesheet">
 
-  <script>
-    $(function () {
-      $('[data-toggle="tooltip"]').tooltip()
-    })
-  </script>
-
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-80600133-2"></script>
   <script>
@@ -200,16 +194,16 @@
                       </th>
                       <td>
                         <div class="dataset_value">
-                          <i class="fa fa-check-circle-o" aria-hidden="{{dataset.quest1}}" data-toggle="tooltip" title="{{getQuestionCode('is_existing', dataset)}}"></i>
-                          <i class="fa fa-desktop" aria-hidden="{{dataset.quest2}}" data-toggle="tooltip" title="{{getQuestionCode('is_digital_form', dataset)}}"></i>
-                          <i class="fa fa-cloud" aria-hidden="{{dataset.quest3}}" data-toggle="tooltip" title="{{getQuestionCode('is_avail_online', dataset)}}"></i>
-                          <i class="fa fa-tag" aria-hidden="{{dataset.quest4}}" data-toggle="tooltip" title="{{getQuestionCode('is_avail_online_meta', dataset)}}"></i>
-                          <i class="fa fa-copy" aria-hidden="{{dataset.quest5}}" data-toggle="tooltip" title="{{getQuestionCode('is_bulk_avail', dataset)}}"></i>
-                          <i class="fa fa-keyboard-o" aria-hidden="{{dataset.quest6}}" data-toggle="tooltip" title="{{getQuestionCode('is_machine_read', dataset)}}"></i>
-                          <i class="fa fa-eye" aria-hidden="{{dataset.quest7}}" data-toggle="tooltip" title="{{getQuestionCode('is_pub_available', dataset)}}"></i>
-                          <i class="fa fa-dollar" aria-hidden="{{dataset.quest8}}" data-toggle="tooltip" title="{{getQuestionCode('is_avail_for_free', dataset)}}"></i>
-                          <i class="fa fa-unlock-alt" aria-hidden="{{dataset.quest9}}" data-toggle="tooltip" title="{{getQuestionCode('is_open_licence', dataset)}}"></i>
-                          <i class="fa fa-clock-o" aria-hidden="{{dataset.quest10}}" data-toggle="tooltip" title="{{getQuestionCode('is_prov_timely', dataset)}}"></i>
+                          <i class="fa fa-check-circle-o" aria-hidden="{{dataset.quest1}}" ng-tooltip title="{{getQuestionCode('is_existing', dataset)}}"></i>
+                          <i class="fa fa-desktop" aria-hidden="{{dataset.quest2}}" ng-tooltip title="{{getQuestionCode('is_digital_form', dataset)}}"></i>
+                          <i class="fa fa-cloud" aria-hidden="{{dataset.quest3}}" ng-tooltip title="{{getQuestionCode('is_avail_online', dataset)}}"></i>
+                          <i class="fa fa-tag" aria-hidden="{{dataset.quest4}}" ng-tooltip title="{{getQuestionCode('is_avail_online_meta', dataset)}}"></i>
+                          <i class="fa fa-copy" aria-hidden="{{dataset.quest5}}" ng-tooltip title="{{getQuestionCode('is_bulk_avail', dataset)}}"></i>
+                          <i class="fa fa-keyboard-o" aria-hidden="{{dataset.quest6}}" ng-tooltip title="{{getQuestionCode('is_machine_read', dataset)}}"></i>
+                          <i class="fa fa-eye" aria-hidden="{{dataset.quest7}}" ng-tooltip title="{{getQuestionCode('is_pub_available', dataset)}}"></i>
+                          <i class="fa fa-dollar" aria-hidden="{{dataset.quest8}}" ng-tooltip title="{{getQuestionCode('is_avail_for_free', dataset)}}"></i>
+                          <i class="fa fa-unlock-alt" aria-hidden="{{dataset.quest9}}" ng-tooltip title="{{getQuestionCode('is_open_licence', dataset)}}"></i>
+                          <i class="fa fa-clock-o" aria-hidden="{{dataset.quest10}}" ng-tooltip title="{{getQuestionCode('is_prov_timely', dataset)}}"></i>
                         </div>
                       </td>
                     </tr>
@@ -218,16 +212,16 @@
               </td>
               <td ng-show="item.istance_id || (!item.istance_id && !item.datasets)">
                 <div class="dataset_value">
-                  <i class="fa fa-check-circle-o" aria-hidden="{{item.quest1}}" data-toggle="tooltip" title="{{getQuestionCode('is_existing', item)}}"></i>
-                  <i class="fa fa-desktop" aria-hidden="{{item.quest2}}" data-toggle="tooltip" title="{{getQuestionCode('is_digital_form', item)}}"></i>
-                  <i class="fa fa-cloud" aria-hidden="{{item.quest3}}" data-toggle="tooltip" title="{{getQuestionCode('is_avail_online', item)}}"></i>
-                  <i class="fa fa-tag" aria-hidden="{{item.quest4}}" data-toggle="tooltip" title="{{getQuestionCode('is_avail_online_meta', item)}}"></i>
-                  <i class="fa fa-copy" aria-hidden="{{item.quest5}}" data-toggle="tooltip" title="{{getQuestionCode('is_bulk_avail', item)}}"></i>
-                  <i class="fa fa-keyboard-o" aria-hidden="{{item.quest6}}" data-toggle="tooltip" title="{{getQuestionCode('is_machine_read', item)}}"></i>
-                  <i class="fa fa-eye" aria-hidden="{{item.quest7}}" data-toggle="tooltip" title="{{getQuestionCode('is_pub_available', item)}}"></i>
-                  <i class="fa fa-dollar" aria-hidden="{{item.quest8}}" data-toggle="tooltip" title="{{getQuestionCode('is_avail_for_free', item)}}"></i>
-                  <i class="fa fa-unlock-alt" aria-hidden="{{item.quest9}}" data-toggle="tooltip" title="{{getQuestionCode('is_open_licence', item)}}"></i>
-                  <i class="fa fa-clock-o" aria-hidden="{{item.quest10}}" data-toggle="tooltip" title="{{getQuestionCode('is_prov_timely', item)}}"></i>
+                  <i class="fa fa-check-circle-o" aria-hidden="{{item.quest1}}" ng-tooltip title="{{getQuestionCode('is_existing', item)}}"></i>
+                  <i class="fa fa-desktop" aria-hidden="{{item.quest2}}" ng-tooltip title="{{getQuestionCode('is_digital_form', item)}}"></i>
+                  <i class="fa fa-cloud" aria-hidden="{{item.quest3}}" ng-tooltip title="{{getQuestionCode('is_avail_online', item)}}"></i>
+                  <i class="fa fa-tag" aria-hidden="{{item.quest4}}" ng-tooltip title="{{getQuestionCode('is_avail_online_meta', item)}}"></i>
+                  <i class="fa fa-copy" aria-hidden="{{item.quest5}}" ng-tooltip title="{{getQuestionCode('is_bulk_avail', item)}}"></i>
+                  <i class="fa fa-keyboard-o" aria-hidden="{{item.quest6}}" ng-tooltip title="{{getQuestionCode('is_machine_read', item)}}"></i>
+                  <i class="fa fa-eye" aria-hidden="{{item.quest7}}" ng-tooltip title="{{getQuestionCode('is_pub_available', item)}}"></i>
+                  <i class="fa fa-dollar" aria-hidden="{{item.quest8}}" ng-tooltip title="{{getQuestionCode('is_avail_for_free', item)}}"></i>
+                  <i class="fa fa-unlock-alt" aria-hidden="{{item.quest9}}" ng-tooltip title="{{getQuestionCode('is_open_licence', item)}}"></i>
+                  <i class="fa fa-clock-o" aria-hidden="{{item.quest10}}" ng-tooltip title="{{getQuestionCode('is_prov_timely', item)}}"></i>
                 </div>
               </td>
             </tr>

--- a/frontend/dataset_list.html
+++ b/frontend/dataset_list.html
@@ -9,7 +9,7 @@
   <meta content="" name="description" />
   <meta content="" name="author" />
 
-  
+
 
   <title>OpenDRI Index - Datasets list</title>
   <link rel="icon" href="img/template/favicon.png" type="image/png">
@@ -177,8 +177,8 @@
           </thead>
           <tbody>
            <tr ng-repeat="item in datasetsByCategory | orderBy: ['-score', 'name'] | filter: checkVisibility" data-score="{{item.score}}" ng-class="{'single-dataset': !item.datasets, 'multiple-datasets': item.datasets}" tabindex="0">
-              <td ng-show="!item.istance_id && !item.datasets" ng-click="changepage('contribute.html?ctr=' + idCountry + '&amp;ds=' +item.name, $event)">
-                <span class="dataset-title">{{item.name}} (<a href="contribute.html?ctr={{idCountry}}&amp;ds={{item.name}}">Contribute</a>)</span>
+              <td ng-show="!item.istance_id && !item.datasets" ng-click="changepage('contribute.html?country_id=' + idCountry + '&amp;ds=' +item.name, $event)">
+                <span class="dataset-title">{{item.name}} (<a href="contribute.html?country_id={{idCountry}}&amp;ds={{item.name}}">Contribute</a>)</span>
               </td>
               <td ng-show="item.istance_id && !item.datasets" ng-click="changepage('dataset_details.html?keyds=' + item.istance_id, $event)">
                 <a ng-href="dataset_details.html?keyds={{item.istance_id}}" class="dataset-title" ng-if="item.istance_id" title="View details">{{item.name}}</a>

--- a/frontend/error_404.html
+++ b/frontend/error_404.html
@@ -50,22 +50,15 @@
     <link href="css/style_map.css" rel="stylesheet">
     <link href="css/land.css" rel="stylesheet">
 
-    <!-- Tooltip init -->
-    <script>
-        $(function () {
-            $('[data-toggle="tooltip"]').tooltip()
-        })
-    </script>
-
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <!--<script async src="https://www.googletagmanager.com/gtag/js?id=UA-80600133-2"></script>-->
-    <!--<script>-->
-        <!--window.dataLayer = window.dataLayer || [];-->
-        <!--function gtag(){dataLayer.push(arguments);}-->
-        <!--gtag('js', new Date());-->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-80600133-2"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-        <!--gtag('config', 'UA-80600133-2');-->
-    <!--</script>-->
+        gtag('config', 'UA-80600133-2');
+    </script>
 </head>
 <body ng-app="RodiApp" ng-controller="RodiCtrl">
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,19 +48,13 @@
     <link href="css/style_map.css" rel="stylesheet">
     <link href="css/land.css" rel="stylesheet">
 
-    <!-- Tooltip init -->
-    <script>
-        $(function () {
-            $('[data-toggle="tooltip"]').tooltip()
-        })
-    </script>
-
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-80600133-2"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
+        gtag('error', '404');
 
         gtag('config', 'UA-80600133-2');
     </script>

--- a/frontend/js/angular/app.js
+++ b/frontend/js/angular/app.js
@@ -79,9 +79,8 @@ var baseUrl = spli_url.protocol + '//' + spli_url.host + '/';
 //     to have full access to development backend from
 //     your local development installation
 //
-var baseAPIurl = '/api/';
-// var baseAPIurl = 'https://dev.riskopendata.org/api/';
-//var baseAPIurl= 'https://index.opendri.org/api/'
+// var baseAPIurl = '/api/';
+var baseAPIurl = 'https://exp.riskopendata.org/api/';
 
 RodiApp.config(function($locationProvider) {
 

--- a/frontend/js/angular/controller.js
+++ b/frontend/js/angular/controller.js
@@ -726,7 +726,7 @@ RodiApp.controller('RodiCtrl', ['$scope', 'RodiSrv', '$window', '$filter', '$loc
     {
 
         $scope.tabpar = $location.search().tab;
-        $scope.countrypar = $location.search().ctr;
+        $scope.country_id = $location.search().country_id;
         $scope.datasetpar = $location.search().ds;
         $scope.questions = RodiSrv.getQuestions();
         $scope.bDescInfo = false;
@@ -921,9 +921,8 @@ RodiApp.controller('RodiCtrl', ['$scope', 'RodiSrv', '$window', '$filter', '$loc
                 $scope.countryList = response.data;
 
                 // Check country parameters
-                if($scope.countrypar)
-                {
-                    $scope.objDataset.country = $scope.countrypar;
+                if($scope.country_id) {
+                    $scope.objDataset.country = $scope.country_id;
                 };
 
                 $scope.getCountryNameReview = function(country)

--- a/frontend/js/angular/controller.js
+++ b/frontend/js/angular/controller.js
@@ -43,8 +43,7 @@ RodiApp.controller('RodiCtrl', ['$scope', 'RodiSrv', '$window', '$filter', '$loc
     // ************************************** //
     // ************ HOME PAGE *************** //
     // ************************************** //
-
-    if ($location.path().indexOf('index') !== -1 || $location.path() == baseUrl.replace("http:/", "") || $location.path() == baseUrl.replace("https:/", ""))
+    if ($location.path().indexOf('index') !== -1 || $location.path() === '/')
     {
 
         $scope.countryWithData = "--";
@@ -106,25 +105,6 @@ RodiApp.controller('RodiCtrl', ['$scope', 'RodiSrv', '$window', '$filter', '$loc
 
         RodiSrv.getHomeStatistics(function(data)
         {
-            //Success API
-
-            // Finding country score for MAP
-            // var arrayStates = [];
-            // var dataTemp = [];
-
-            // angular.forEach(data.scores, function(value, key)
-            // {
-            //     arrayStates.push(value.country);
-            // });
-
-            // angular.forEach(arrayStates, function(value, key)
-            // {
-            //     var obj = $filter('filter')(data.scores, {country: value});
-            //     dataTemp[value] = {score: obj[0].score};
-            // });
-
-            // $scope.arrayData = dataTemp;
-
             // Statistics index
 
             $scope.getPelirsIcons = function(code)

--- a/frontend/js/angular/directive.js
+++ b/frontend/js/angular/directive.js
@@ -103,15 +103,6 @@ RodiApp.directive('region', ['$compile', '$window', function ($compile, $window)
     }
 }]);
 
-// RodiApp.directive('hazardmenu',function(){
-//     return {
-//         transclude: true,
-//         restrict: 'E',
-//         controller: "RodiCtrl",
-//         templateUrl: 'views/hazard_menu.html'
-//     }
-// });
-
 RodiApp.directive('mainmenu',function(){
     return {
         transclude: true,
@@ -120,15 +111,6 @@ RodiApp.directive('mainmenu',function(){
         templateUrl: 'views/web_menu.html'
     }
 });
-
-// RodiApp.directive('browsedata',function(){
-//     return {
-//         transclude: true,
-//         restrict: 'E',
-//         controller: "RodiCtrl",
-//         templateUrl: 'views/browse_data.html'
-//     }
-// });
 
 RodiApp.directive('rodifooter',function(){
     return {
@@ -148,11 +130,16 @@ RodiApp.directive('loginform',function(){
     }
 });
 
-// RodiApp.directive('helpfeedbackbox',function(){
-//     return {
-//         transclude: true,
-//         restrict: 'E',
-//         controller: "RodiCtrlMainMenu",
-//         templateUrl: 'views/help_feedback_view.html'
-//     }
-// });
+RodiApp.directive('ngTooltip', function() {
+  function enableTooltips (scope, element, attrs) {
+    $(element).tooltip({
+      container: 'body',
+      title: attrs.ngTooltip || attrs.title
+    });
+  }
+
+  return {
+    restrict: 'A',
+    link: enableTooltips
+  }
+});

--- a/frontend/js/angular/service.js
+++ b/frontend/js/angular/service.js
@@ -1451,7 +1451,7 @@ RodiApp.service("RodiSrv", ['$http', '$filter', '$window', function($http, $filt
 
         return $http({
               method: 'GET',
-              url: baseAPIurl + 'country_scoring/?' + queryString,
+              url: baseAPIurl + 'scoring/?' + queryString,
               headers: { },
               data: { }
           })

--- a/frontend/news-details.html
+++ b/frontend/news-details.html
@@ -8,7 +8,7 @@
     <meta content="" name="description" />
     <meta content="" name="author" />
 
-    
+
 
     <title>OpenDRI Index - Country Details</title>
     <link rel="icon" href="img/template/favicon.png" type="image/png">
@@ -64,7 +64,7 @@
                <section id="header">
 
                    <helpfeedbackbox></helpfeedbackbox>
-                   <a ng-if="bHome" href="index.html" data-toggle="tooltip" title="Home">
+                   <a ng-if="bHome" href="index.html" ng-tooltip title="Home">
                        <img src="img/template/rodi_logo_new.png" alt="Open Data for Resilience Initiative" class="img-responsive" />
                    </a>
 

--- a/frontend/wsrv-config.json
+++ b/frontend/wsrv-config.json
@@ -2,7 +2,7 @@
   "proxy": {
     "/api/{p*}": {
       "options": {
-        "host": "dev.riskopendata.org",
+        "host": "exp.riskopendata.org",
         "protocol": "https",
         "passThrough": true
       }


### PR DESCRIPTION
- [x] display country open data indicators (fix #305)
- [x] display available criteria data
- [x] rewire the data with `/api/scoring` instead of `/api/country_scoring` (aligned with `be_scoring-new` branch) 
- [x] update sorting options

👁 [**Live Preview**](https://deploy-preview-424--index-opendri-preview.netlify.com/)

 