### PR TITLE
Use universal single-line to split overflowing lines

### DIFF
--- a/frontend/css/rodi_css.css
+++ b/frontend/css/rodi_css.css
@@ -58,12 +58,15 @@ h3, h4, h5, h6
   border-bottom: none;
 }
 
-.single-line {
+.single-line,
+.trunkate {
   display: inline-block;
-  max-width: 100%;
   overflow: hidden;
   text-overflow: " […]";
   white-space: nowrap;
+}
+.trunkate {
+  display: block;
 }
 
 .success {
@@ -364,54 +367,6 @@ h1 + .lead {
     font-weight: 500;
 }
 
-
-/*
-==============================================================================
-    truncate lines
-==============================================================================
-*/
-
-
-
-.trunkate {
-    background: transparent;
-    display: block;
-    /* Fallback for non-webkit */
-    display: -webkit-box;
-    max-height: 3.38rem;
-    /* Fallback for non-webkit */
-    font-size: 1.3rem;
-    line-height: 1.3;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    margin-bottom: 0;
-}
-@-moz-document url-prefix() {
-    .trunkate {
-        overflow: hidden;
-        position: relative;
-    }
-    .trunkate:before {
-        background: transparent;
-        bottom: 0;
-        position: absolute;
-        right: 0;
-        float: right;
-        content: '\2026';
-        margin-left: -3rem;
-        width: 3rem;
-    }
-    .trunkate:after {
-        content: '';
-        background: transparent;
-        position: absolute;
-        height: 50px;
-        width: 100%;
-        z-index: 1;
-    }
-}
 
 /*
 ==============================================================================
@@ -1317,7 +1272,8 @@ Tables
   }
   .datasets-table > tbody > tr > :first-child {
     min-width: 200px;
-    width: 45%;
+    max-width: 450px;
+    width: 450px;
   }
   .datasets-table > tbody > tr.multiple-datasets > td {
     padding-left: 0;

--- a/frontend/css/rodi_css.css
+++ b/frontend/css/rodi_css.css
@@ -62,6 +62,7 @@ h3, h4, h5, h6
 .trunkate {
   display: inline-block;
   overflow: hidden;
+  max-width: 100%;
   text-overflow: " […]";
   white-space: nowrap;
 }

--- a/frontend/dataset_list.html
+++ b/frontend/dataset_list.html
@@ -171,7 +171,8 @@
                 <a ng-href="dataset_details.html?keyds={{item.dataset_id}}" class="dataset-title" ng-if="item.dataset_id" title="View details">{{item.name}}</a>
                 <span class="dataset-title" ng-if="item.datasets">{{item.name}}</span>
                 <div class="rodi_subtitle_datasetlist" ng-show="item.dataset_id">
-                  <span class="text-muted trunkate">{{item.title.toString() + ' ' + item.institution.toString() + ' ' + item.modify_time.toString()}}</span>
+                  <span class="text-muted trunkate">{{item.title || item.name}} {{item.institution}}</span>
+                  <span class="text-muted" ng-show="item.modify_time">{{item.modify_time}}</span>
                 </div>
               </td>
               <td ng-show="item.dataset_id && !item.datasets" ng-click="changepage('dataset_details.html?keyds=' + item.dataset_id, $event)">
@@ -196,7 +197,8 @@
                     <tr ng-repeat="dataset in item.datasets | orderBy: ['-openness', 'name']  | filter: checkVisibility" ng-click="changepage('dataset_details.html?keyds=' + dataset.dataset_id, $event)" tabindex="0">
                       <th scope="row" data-openness="{{dataset.openness}}" data-dataset-id="{{dataset.dataset_id}}">
                         <div class="rodi_subtitle_datasetlist" ng-show="dataset.dataset_id">
-                          <span class=" text-muted trunkate">{{dataset.title.toString() + ' ' + dataset.institution.toString() + ' ' + dataset.modify_time.toString()}}</span>
+                          <a ng-href="dataset_details.html?keyds={{dataset.dataset_id}}" class="text-muted trunkate" title="{{dataset.title || dataset.name}}">{{dataset.title || dataset.name}} {{dataset.institution}}</a>
+                          <span class="text-muted" ng-show="dataset.modify_time">{{dataset.modify_time}}</span>
                         </div>
                       </th>
                       <td>


### PR DESCRIPTION
To have a universal approach, I clamped only the first line (which can be long) and let the second one be more "free flow" (it displays only the date, when available).

<img width="967" alt="image" src="https://user-images.githubusercontent.com/138627/52583935-11e4e700-2e31-11e9-9c5a-39d8502edf68.png">

fix #371