### PR TITLE
Enable Django ConditionalGetMiddleware

### DIFF
--- a/backend/ordd/settings.py.tmpl
+++ b/backend/ordd/settings.py.tmpl
@@ -57,6 +57,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.http.ConditionalGetMiddleware'
 ]
 
 CORS_ORIGIN_ALLOW_ALL = True


### PR DESCRIPTION
Thus, it adds a `Content-Length` response header.

Ngninx uses `Content-Length` to decide if yes or no, it compresses the output. With this feature enabled, [API responses will be gzipped by Nginx](http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_min_length), with the expectation of a quicker time to interaction in pages.